### PR TITLE
Add prominent live demo calls to action

### DIFF
--- a/docs/website-src/generate.mjs
+++ b/docs/website-src/generate.mjs
@@ -140,8 +140,7 @@ for (const [locale, details] of locales) {
 		.replaceAll('{{LANGUAGE_MENU}}', languageMenu(locale));
 	if (/{{[A-Z_]+}}/.test(html)) fail(`${locale} output contains an unresolved placeholder`);
 
-	const languageScript = `
-		<script>
+	const languageScript = `\t<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {
 					try { localStorage.setItem('pv_website_language', link.dataset.language); } catch {}

--- a/docs/website-src/index.html
+++ b/docs/website-src/index.html
@@ -1286,7 +1286,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Main navigation">
 				<a href="#story">How it works</a><a href="#features">Why families use it</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Try live demo ↗</a>{{LANGUAGE_MENU}}
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Try live demo ↗</a
+				>{{LANGUAGE_MENU}}
 			</nav>
 		</header>
 		<main id="content">
@@ -1300,9 +1302,13 @@
 							let Popcorn Vote choose tonight’s winner.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Try live demo <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Self-host Popcorn Vote <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1538,7 +1544,7 @@
 					<p class="eyebrow">Your next movie night starts here</p>
 					<h2>Keep the choice fair. Keep the evening fun.</h2>
 					<p>Popcorn Vote is free, open source, and ready to run on your own server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>View setup on GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1550,7 +1556,11 @@
 					>A family project by Stadicus <span aria-hidden="true">·</span> MIT licensed</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1561,7 +1571,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website-src/index.html
+++ b/docs/website-src/index.html
@@ -1286,8 +1286,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Main navigation">
 				<a href="#story">How it works</a><a href="#features">Why families use it</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">View on GitHub ↗</a
-				>{{LANGUAGE_MENU}}
+				><a class="nav-cta" href="https://demo.popcornvote.org">Try live demo ↗</a>{{LANGUAGE_MENU}}
 			</nav>
 		</header>
 		<main id="content">
@@ -1301,9 +1300,11 @@
 							let Popcorn Vote choose tonight’s winner.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Set up Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">How it works <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Try live demo <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Self-host Popcorn Vote <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Free and open source.</b> Your family’s film diary stays on your server.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Make it pop</button>

--- a/docs/website-src/messages.json
+++ b/docs/website-src/messages.json
@@ -71,12 +71,12 @@
 			"Main navigation",
 			"How it works",
 			"Why families use it",
-			"View on GitHub ↗",
+			"Try live demo ↗",
 			"A fairer way to choose the film",
 			"Movie night,",
 			"chosen by you.",
 			"Everyone suggests films and gets votes on the same schedule. Save them, back a favourite, and let Popcorn Vote choose tonight’s winner.",
-			"Set up Popcorn Vote",
+			"Self-host Popcorn Vote",
 			"Free and open source.",
 			"Your family’s film diary stays on your server.",
 			"Make it pop",
@@ -141,7 +141,8 @@
 			"Movie List showing how many votes each family member has placed",
 			"The Popcorn Vote wheel of fortune resolving a tied vote",
 			"The winning film displayed on the Popcorn Vote Movie Night screen",
-			"Popcorn Vote TV mode showing the winning movie on a television-friendly screen"
+			"Popcorn Vote TV mode showing the winning movie on a television-friendly screen",
+			"Try live demo"
 		],
 		"de": [
 			"Popcorn Vote ist eine kostenlose, selbst gehostete App für den Familienfilmabend. Schlagen Sie Filme vor, sammeln Sie Stimmen, lösen Sie Stimmengleichheit mit einem Rad auf und führen Sie ein gemeinsames Filmtagebuch.",
@@ -156,12 +157,12 @@
 			"Hauptnavigation",
 			"Wie es funktioniert",
 			"Warum Familien es nutzen",
-			"Auf GitHub ansehen ↗",
+			"Live-Demo testen ↗",
 			"Eine fairere Möglichkeit, den Film auszuwählen",
 			"Filmabend,",
 			"von Ihnen gewählt.",
 			"Jeder schlägt Filme vor und erhält nach dem gleichen Zeitplan Stimmen. Sammeln Sie sie, unterstützen Sie einen Favoriten und lassen Sie Popcorn Vote den Gewinner des heutigen Abends auswählen.",
-			"Popcorn Vote einrichten",
+			"Popcorn Vote selbst hosten",
 			"Kostenlos und Open Source.",
 			"Das Filmtagebuch Ihrer Familie bleibt auf Ihrem Server.",
 			"Lass es platzen",
@@ -226,7 +227,8 @@
 			"Filmliste, die zeigt, wie viele Stimmen jedes Familienmitglied abgegeben hat",
 			"Das Popcorn Vote-Glücksrad entscheidet über eine Stimmengleichheit",
 			"Der Gewinnerfilm wird auf dem Bildschirm „PV⟧ Movie Night“ angezeigt",
-			"Popcorn Vote TV-Modus, der den Gewinnerfilm auf einem fernsehfreundlichen Bildschirm zeigt"
+			"Popcorn Vote TV-Modus, der den Gewinnerfilm auf einem fernsehfreundlichen Bildschirm zeigt",
+			"Live-Demo testen"
 		],
 		"es": [
 			"Popcorn Vote es una aplicación gratuita y autohospedada para una noche de cine familiar. Sugiera películas, acumule votos, resuelva empates con una rueda y lleve un diario cinematográfico compartido.",
@@ -241,12 +243,12 @@
 			"Navegación principal",
 			"como funciona",
 			"Por qué las familias lo usan",
-			"Ver en GitHub ↗",
+			"Probar la demo en vivo ↗",
 			"Una forma más justa de elegir la película",
 			"noche de cine,",
 			"elegido por ti.",
 			"Todos proponen películas y obtienen votaciones en el mismo horario. Acumúlelos, apoye a un favorito y deje que Popcorn Vote elija al ganador de esta noche.",
-			"Configurar Popcorn Vote",
+			"Alojar Popcorn Vote",
 			"Gratis y de código abierto.",
 			"El diario cinematográfico de su familia permanece en su servidor.",
 			"Hazlo resaltar",
@@ -311,7 +313,8 @@
 			"Lista de películas que muestra cuántos votos ha realizado cada miembro de la familia",
 			"La rueda de la fortuna Popcorn Vote que resuelve un empate en la votación",
 			"La película ganadora se exhibirá en la pantalla Popcorn Vote Movie Night",
-			"Popcorn Vote Modo TV que muestra la película ganadora en una pantalla compatible con televisión"
+			"Popcorn Vote Modo TV que muestra la película ganadora en una pantalla compatible con televisión",
+			"Probar la demo en vivo"
 		],
 		"fr": [
 			"Popcorn Vote est une application gratuite et auto-hébergée pour une soirée cinéma en famille. Suggérez des films, accumulez des votes, résolvez les votes à égalité avec une roue et tenez un journal de film partagé.",
@@ -326,12 +329,12 @@
 			"Navigation principale",
 			"Comment ça marche",
 			"Pourquoi les familles l'utilisent",
-			"Voir sur GitHub ↗",
+			"Essayer la démo en direct ↗",
 			"Une manière plus juste de choisir le film",
 			"Soirée cinéma,",
 			"choisi par vous.",
 			"Tout le monde suggère des films et obtient des votes selon le même calendrier. Accumulez-les, soutenez un favori et laissez Popcorn Vote choisir le gagnant de ce soir.",
-			"Configurer Popcorn Vote",
+			"Auto-héberger Popcorn Vote",
 			"Gratuit et open source.",
 			"Le journal cinématographique de votre famille reste sur votre serveur.",
 			"Faites-le éclater",
@@ -396,7 +399,8 @@
 			"Liste de films indiquant le nombre de votes attribués par chaque membre de la famille",
 			"La roue de la fortune Popcorn Vote résout un vote à égalité",
 			"Le film gagnant affiché sur l'écran Popcorn Vote Movie Night",
-			"Mode TV Popcorn Vote montrant le film gagnant sur un écran compatible avec la télévision"
+			"Mode TV Popcorn Vote montrant le film gagnant sur un écran compatible avec la télévision",
+			"Essayer la démo en direct"
 		],
 		"pt-BR": [
 			"Popcorn Vote é um aplicativo gratuito e auto-hospedado para noites de cinema em família. Sugira filmes, acumule votos, resolva votos empatados com uma roda e mantenha um diário de filmes compartilhado.",
@@ -411,12 +415,12 @@
 			"Navegação principal",
 			"Como funciona",
 			"Por que as famílias usam",
-			"Ver no GitHub ↗",
+			"Testar demonstração ao vivo ↗",
 			"Uma forma mais justa de escolher o filme",
 			"Noite de cinema,",
 			"escolhido por você.",
 			"Todos sugerem filmes e recebem votos no mesmo horário. Acumule-os, apoie um favorito e deixe Popcorn Vote escolher o vencedor desta noite.",
-			"Configurar Popcorn Vote",
+			"Auto-hospedar Popcorn Vote",
 			"Gratuito e de código aberto.",
 			"O diário cinematográfico da sua família permanece no seu servidor.",
 			"Faça estourar",
@@ -481,7 +485,8 @@
 			"Lista de filmes mostrando quantos votos cada membro da família deu",
 			"A roda da fortuna Popcorn Vote resolvendo uma votação empatada",
 			"O filme vencedor exibido na tela Popcorn Vote Movie Night",
-			"Popcorn Vote Modo TV mostrando o filme vencedor em uma tela adequada para televisão"
+			"Popcorn Vote Modo TV mostrando o filme vencedor em uma tela adequada para televisão",
+			"Testar demonstração ao vivo"
 		],
 		"it": [
 			"Popcorn Vote è un'app gratuita e self-hosted per serate di cinema in famiglia. Suggerisci film, accumula voti, risolvi i voti in parità con una ruota e tieni un diario cinematografico condiviso.",
@@ -496,12 +501,12 @@
 			"Navigazione principale",
 			"Come funziona",
 			"Perché le famiglie lo usano",
-			"Visualizza su GitHub ↗",
+			"Prova la demo online ↗",
 			"Un modo più giusto per scegliere il film",
 			"Serata al cinema,",
 			"scelto da te.",
 			"Tutti suggeriscono film e ricevono voti secondo lo stesso programma. Accumulali, sostieni un favorito e lascia che Popcorn Vote scelga il vincitore di stasera.",
-			"Imposta Popcorn Vote",
+			"Ospita Popcorn Vote sul tuo server",
 			"Gratuito e open source.",
 			"Il diario cinematografico della tua famiglia rimane sul tuo server.",
 			"Fallo scoppiare",
@@ -566,7 +571,8 @@
 			"Elenco dei film che mostra quanti voti ha assegnato ciascun membro della famiglia",
 			"La ruota della fortuna Popcorn Vote risolve un voto in parità",
 			"Il film vincitore verrà visualizzato sullo schermo Popcorn Vote Movie Night",
-			"Popcorn Vote Modalità TV che mostra il film vincitore su uno schermo adatto alla televisione"
+			"Popcorn Vote Modalità TV che mostra il film vincitore su uno schermo adatto alla televisione",
+			"Prova la demo online"
 		],
 		"pl": [
 			"Popcorn Vote to bezpłatna aplikacja hostowana na własnym serwerze, przeznaczona na rodzinny wieczór filmowy. Sugeruj filmy, zbieraj głosy, rozstrzygaj remisowe głosy za pomocą koła i prowadź wspólny dziennik filmowy.",
@@ -581,12 +587,12 @@
 			"Główna nawigacja",
 			"Jak to działa",
 			"Dlaczego rodziny z niego korzystają",
-			"Zobacz na GitHubie ↗",
+			"Wypróbuj demo na żywo ↗",
 			"Bardziej sprawiedliwy sposób wyboru filmu",
 			"Wieczór filmowy,",
 			"wybrany przez Ciebie.",
 			"Wszyscy sugerują filmy i otrzymują głosy według tego samego harmonogramu. Zbieraj je, wspieraj faworyta i pozwól Popcorn Vote wybrać dzisiejszego zwycięzcę.",
-			"Skonfiguruj Popcorn Vote",
+			"Hostuj Popcorn Vote samodzielnie",
 			"Darmowe i otwarte źródło.",
 			"Dziennik filmowy Twojej rodziny pozostaje na Twoim serwerze.",
 			"Spraw, żeby to wystrzeliło",
@@ -651,7 +657,8 @@
 			"Lista filmów pokazująca, ile głosów oddał każdy członek rodziny",
 			"Koło fortuny Popcorn Vote rozstrzygające remisową liczbę głosów",
 			"Zwycięski film wyświetlany na ekranie Nocy Filmowej Popcorn Vote",
-			"Popcorn Vote Tryb telewizyjny pokazujący zwycięski film na ekranie przyjaznym dla telewizji"
+			"Popcorn Vote Tryb telewizyjny pokazujący zwycięski film na ekranie przyjaznym dla telewizji",
+			"Wypróbuj demo na żywo"
 		],
 		"tr": [
 			"Popcorn Vote aile film geceleri için ücretsiz, kendi kendine barındırılan bir uygulamadır. Film önerin, oy toplayın, eşit oyları çarkla çözün ve ortak bir film günlüğü tutun.",
@@ -666,12 +673,12 @@
 			"Ana gezinme",
 			"Nasıl çalışır?",
 			"Aileler bunu neden kullanıyor?",
-			"GitHub'da görüntüle ↗",
+			"Canlı demoyu dene ↗",
 			"Filmi seçmenin daha adil bir yolu",
 			"Film gecesi,",
 			"sizin tarafınızdan seçilmiş.",
 			"Herkes aynı programda film önerir ve oy alır. Bunları toplayın, bir favoriyi destekleyin ve Popcorn Vote'nin bu gecenin kazananını seçmesine izin verin.",
-			"Popcorn Vote'yi kurun",
+			"Popcorn Vote’u kendin barındır",
 			"Ücretsiz ve açık kaynak.",
 			"Ailenizin film günlüğü sunucunuzda kalır.",
 			"Pop yap",
@@ -736,7 +743,8 @@
 			"Her aile üyesinin kaç oy verdiğini gösteren Film Listesi",
 			"Eşit oylu bir oyu çözen Popcorn Vote çarkıfelek",
 			"Kazanan film Popcorn Vote Film Gecesi ekranında gösteriliyor",
-			"Popcorn Vote Kazanan filmi televizyona uygun bir ekranda gösteren TV modu"
+			"Popcorn Vote Kazanan filmi televizyona uygun bir ekranda gösteren TV modu",
+			"Canlı demoyu dene"
 		],
 		"ja": [
 			"Popcorn Vote は、家族で映画鑑賞をするための無料の自己ホスト型アプリです。映画を提案し、投票を蓄積し、ホイールで同数の票を解決し、共有の映画日記を付けます。",
@@ -751,12 +759,12 @@
 			"メインナビゲーション",
 			"仕組み",
 			"家族が利用する理由",
-			"GitHub で見る ↗",
+			"ライブデモを試す ↗",
 			"映画を選ぶためのより公平な方法",
 			"映画の夜、",
 			"あなたが選んだもの。",
 			"全員が同じスケジュールで映画を提案し、投票を行います。それらを蓄積し、お気に入りをサポートし、Popcorn Vote に今夜の勝者を選ばせてください。",
-			"Popcorn Voteを設定する",
+			"Popcorn Voteをセルフホストする",
 			"無料でオープンソース。",
 			"家族の映画日記はサーバーに残ります。",
 			"ポップにする",
@@ -821,7 +829,8 @@
 			"各家族が何票投票したかを示す映画リスト",
 			"同数票を解決するPopcorn Vote運命の輪",
 			"Popcorn Vote Movie Night スクリーンに表示される受賞作品",
-			"Popcorn Vote 受賞映画をテレビ向けの画面で表示する TV モード"
+			"Popcorn Vote 受賞映画をテレビ向けの画面で表示する TV モード",
+			"ライブデモを試す"
 		]
 	}
 }

--- a/docs/website/assets/fonts/OFL-DM-Mono.txt
+++ b/docs/website/assets/fonts/OFL-DM-Mono.txt
@@ -18,7 +18,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/docs/website/assets/fonts/OFL-DM-Sans.txt
+++ b/docs/website/assets/fonts/OFL-DM-Sans.txt
@@ -18,7 +18,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/docs/website/assets/fonts/OFL-Nunito-Sans.txt
+++ b/docs/website/assets/fonts/OFL-Nunito-Sans.txt
@@ -18,7 +18,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Hauptnavigation">
 				<a href="#story">Wie es funktioniert</a><a href="#features">Warum Familien es nutzen</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Live-Demo testen ↗</a><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Live-Demo testen ↗</a
+				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Alle schlagen Filme vor und erhalten regelmäßig neue Stimmen. Spare sie an, unterstütze deinen Favoriten – und lass Popcorn Vote den Film für heute Abend küren.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Live-Demo testen <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Popcorn Vote selbst hosten <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">Dein nächster Filmabend beginnt hier</p>
 					<h2>Fair entscheiden. Filmabend genießen.</h2>
 					<p>Popcorn Vote ist kostenlos, Open Source und startklar für deinen eigenen Server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Setup auf GitHub ansehen <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Ein Familienprojekt von Stadicus <span aria-hidden="true">·</span> MIT-lizenziert</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Hauptnavigation">
 				<a href="#story">Wie es funktioniert</a><a href="#features">Warum Familien es nutzen</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">Auf GitHub ansehen ↗</a
-				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Live-Demo testen ↗</a><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Alle schlagen Filme vor und erhalten regelmäßig neue Stimmen. Spare sie an, unterstütze deinen Favoriten – und lass Popcorn Vote den Film für heute Abend küren.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Popcorn Vote einrichten <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">Wie es funktioniert <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Live-Demo testen <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Popcorn Vote selbst hosten <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Kostenlos und Open Source.</b> Das Filmtagebuch deiner Familie bleibt auf deinem Server.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Popcorn platzen lassen</button>

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Main navigation">
 				<a href="#story">How it works</a><a href="#features">Why families use it</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Try live demo ↗</a><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Try live demo ↗</a
+				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1319,13 @@
 							let Popcorn Vote choose tonight’s winner.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Try live demo <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Self-host Popcorn Vote <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1555,7 +1561,7 @@
 					<p class="eyebrow">Your next movie night starts here</p>
 					<h2>Keep the choice fair. Keep the evening fun.</h2>
 					<p>Popcorn Vote is free, open source, and ready to run on your own server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>View setup on GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1567,7 +1573,11 @@
 					>A family project by Stadicus <span aria-hidden="true">·</span> MIT licensed</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1578,7 +1588,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -1683,7 +1683,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Main navigation">
 				<a href="#story">How it works</a><a href="#features">Why families use it</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">View on GitHub ↗</a
-				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Try live demo ↗</a><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1318,9 +1317,11 @@
 							let Popcorn Vote choose tonight’s winner.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Set up Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">How it works <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Try live demo <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Self-host Popcorn Vote <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Free and open source.</b> Your family’s film diary stays on your server.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Make it pop</button>

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Navegación principal">
 				<a href="#story">como funciona</a><a href="#features">Por qué las familias lo usan</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">Ver en GitHub ↗</a
-				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Probar la demo en vivo ↗</a><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Todos proponen películas y reciben votos según el mismo calendario. Acumúlalos, apoya una favorita y deja que Popcorn Vote elija a la ganadora de esta noche.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Configurar Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">como funciona <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Probar la demo en vivo <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Alojar Popcorn Vote <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Gratis y de código abierto.</b> El diario de cine de tu familia permanece en tu servidor.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Haz que estalle</button>

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Navegación principal">
 				<a href="#story">como funciona</a><a href="#features">Por qué las familias lo usan</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Probar la demo en vivo ↗</a><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Probar la demo en vivo ↗</a
+				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Todos proponen películas y reciben votos según el mismo calendario. Acumúlalos, apoya una favorita y deja que Popcorn Vote elija a la ganadora de esta noche.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Probar la demo en vivo <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Alojar Popcorn Vote <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">Tu próxima noche de cine comienza aquí</p>
 					<h2>Una elección justa. Una noche divertida.</h2>
 					<p>Popcorn Vote es gratuito, de código abierto y está listo para ejecutarse en tu propio servidor.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Ver configuración en GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Un proyecto familiar de Stadicus <span aria-hidden="true">·</span> licencia MIT</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Navigation principale">
 				<a href="#story">Comment ça marche</a><a href="#features">Pourquoi les familles l'utilisent</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">Voir sur GitHub ↗</a
-				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Essayer la démo en direct ↗</a><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Tout le monde propose des films et reçoit des votes selon le même calendrier. Accumule-les, soutiens un favori et laisse Popcorn Vote choisir le gagnant de ce soir.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Configurer Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">Comment ça marche <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Essayer la démo en direct <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Auto-héberger Popcorn Vote <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Gratuit et open source.</b> Le journal cinéma de ta famille reste sur ton serveur.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Fais éclater le popcorn</button>

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Navigation principale">
 				<a href="#story">Comment ça marche</a><a href="#features">Pourquoi les familles l'utilisent</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Essayer la démo en direct ↗</a><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Essayer la démo en direct ↗</a
+				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Tout le monde propose des films et reçoit des votes selon le même calendrier. Accumule-les, soutiens un favori et laisse Popcorn Vote choisir le gagnant de ce soir.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Essayer la démo en direct <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Auto-héberger Popcorn Vote <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">Ta prochaine soirée cinéma commence ici</p>
 					<h2>Un choix équitable. Une soirée réussie.</h2>
 					<p>Popcorn Vote est gratuit, open source et prêt à fonctionner sur ton propre serveur.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Afficher la configuration sur GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Un projet familial signé Stadicus <span aria-hidden="true">·</span> Licence MIT</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Navigazione principale">
 				<a href="#story">Come funziona</a><a href="#features">Perché le famiglie lo usano</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">Visualizza su GitHub ↗</a
-				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Prova la demo online ↗</a><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Tutti propongono film e ricevono voti con lo stesso ritmo. Accumulali, sostieni un favorito e lascia che Popcorn Vote scelga il vincitore di stasera.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Imposta Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">Come funziona <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Prova la demo online <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Ospita Popcorn Vote sul tuo server <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Gratuito e open source.</b> Il diario cinematografico della tua famiglia rimane sul tuo server.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Fai scoppiare i popcorn</button>

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Navigazione principale">
 				<a href="#story">Come funziona</a><a href="#features">Perché le famiglie lo usano</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Prova la demo online ↗</a><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Prova la demo online ↗</a
+				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Tutti propongono film e ricevono voti con lo stesso ritmo. Accumulali, sostieni un favorito e lascia che Popcorn Vote scelga il vincitore di stasera.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Prova la demo online <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Ospita Popcorn Vote sul tuo server <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">La tua prossima serata al cinema inizia qui</p>
 					<h2>Una scelta equa. Una serata divertente.</h2>
 					<p>Popcorn Vote è gratuito, open source e pronto per essere eseguito sul tuo server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Visualizza la configurazione su GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Un progetto familiare targato Stadicus <span aria-hidden="true">·</span> Licenza MIT</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="メインナビゲーション">
 				<a href="#story">仕組み</a><a href="#features">家族が利用する理由</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">GitHub で見る ↗</a
-				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">ライブデモを試す ↗</a><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							全員が映画を提案し、同じスケジュールで投票権を受け取ります。投票を貯めてお気に入りを応援し、今夜の一本を Popcorn Vote に決めてもらいましょう。
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Popcorn Voteを設定する <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">仕組み <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>ライブデモを試す <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Popcorn Voteをセルフホストする <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>無料でオープンソース。</b> 家族の映画日記はサーバーに残ります。</p>
 						<button class="pop-trigger" type="button" aria-live="polite">ポップコーンを弾けさせる</button>

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="メインナビゲーション">
 				<a href="#story">仕組み</a><a href="#features">家族が利用する理由</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">ライブデモを試す ↗</a><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>ライブデモを試す ↗</a
+				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							全員が映画を提案し、同じスケジュールで投票権を受け取ります。投票を貯めてお気に入りを応援し、今夜の一本を Popcorn Vote に決めてもらいましょう。
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>ライブデモを試す <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Popcorn Voteをセルフホストする <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">次の映画の夜はここから始まります</p>
 					<h2>公平に選ぶ。楽しい夜を過ごす。</h2>
 					<p>Popcorn Vote は無料のオープンソースで、独自のサーバー上ですぐに実行できます。</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>GitHub でセットアップを表示する <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Stadicus による家族プロジェクト <span aria-hidden="true">·</span> MITライセンス取得済み</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Główna nawigacja">
 				<a href="#story">Jak to działa</a><a href="#features">Dlaczego rodziny z niego korzystają</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Wypróbuj demo na żywo ↗</a><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Wypróbuj demo na żywo ↗</a
+				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Wszyscy proponują filmy i otrzymują głosy według tego samego harmonogramu. Gromadź je, wspieraj faworyta i pozwól Popcorn Vote wybrać dzisiejszego zwycięzcę.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Wypróbuj demo na żywo <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Hostuj Popcorn Vote samodzielnie <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">Twój kolejny wieczór filmowy zaczyna się tutaj</p>
 					<h2>Uczciwy wybór. Udany wieczór.</h2>
 					<p>Popcorn Vote jest darmowym, otwartym oprogramowaniem gotowym do uruchomienia na twoim własnym serwerze.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Zobacz konfigurację w GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Projekt rodzinny autorstwa Stadicusa <span aria-hidden="true">·</span> Licencja MIT</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Główna nawigacja">
 				<a href="#story">Jak to działa</a><a href="#features">Dlaczego rodziny z niego korzystają</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">Zobacz na GitHubie ↗</a
-				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Wypróbuj demo na żywo ↗</a><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Wszyscy proponują filmy i otrzymują głosy według tego samego harmonogramu. Gromadź je, wspieraj faworyta i pozwól Popcorn Vote wybrać dzisiejszego zwycięzcę.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Skonfiguruj Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">Jak to działa <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Wypróbuj demo na żywo <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Hostuj Popcorn Vote samodzielnie <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Darmowe i otwarte źródło.</b> Dziennik filmowy twojej rodziny pozostaje na twoim serwerze.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Niech popcorn wystrzeli</button>

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Navegação principal">
 				<a href="#story">Como funciona</a><a href="#features">Por que as famílias usam</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">Ver no GitHub ↗</a
-				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Testar demonstração ao vivo ↗</a><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Todos sugerem filmes e recebem votos no mesmo cronograma. Acumule-os, apoie um favorito e deixe o Popcorn Vote escolher o vencedor desta noite.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Configurar Popcorn Vote <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">Como funciona <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Testar demonstração ao vivo <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Auto-hospedar Popcorn Vote <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Gratuito e de código aberto.</b> O diário cinematográfico da sua família permanece no seu servidor.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Faça a pipoca estourar</button>

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Navegação principal">
 				<a href="#story">Como funciona</a><a href="#features">Por que as famílias usam</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Testar demonstração ao vivo ↗</a><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Testar demonstração ao vivo ↗</a
+				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Todos sugerem filmes e recebem votos no mesmo cronograma. Acumule-os, apoie um favorito e deixe o Popcorn Vote escolher o vencedor desta noite.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Testar demonstração ao vivo <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Auto-hospedar Popcorn Vote <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">Sua próxima noite de cinema começa aqui</p>
 					<h2>Uma escolha justa. Uma noite divertida.</h2>
 					<p>Popcorn Vote é gratuito, de código aberto e pronto para ser executado em seu próprio servidor.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Veja a configuração no GitHub <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Um projeto familiar da Stadicus <span aria-hidden="true">·</span> Licenciado pelo MIT</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -1303,8 +1303,7 @@
 			</button>
 			<nav class="nav-links" aria-label="Ana gezinme">
 				<a href="#story">Nasıl çalışır?</a><a href="#features">Aileler bunu neden kullanıyor?</a
-				><a class="nav-cta" href="https://github.com/Stadicus/popcorn-vote">GitHub'da görüntüle ↗</a
-				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org">Canlı demoyu dene ↗</a><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1317,9 +1316,11 @@
 							Herkes film önerir ve aynı programa göre oy alır. Oylarını biriktir, favorini destekle ve bu gecenin kazananını Popcorn Vote seçsin.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://github.com/Stadicus/popcorn-vote"
-								>Popcorn Vote'yi kurun <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="#story">Nasıl çalışır? <span aria-hidden="true">↓</span></a>
+							<a class="button" href="https://demo.popcornvote.org"
+								>Canlı demoyu dene <span aria-hidden="true">↗</span></a
+							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+								>Popcorn Vote’u kendin barındır <span aria-hidden="true">↗</span></a
+							>
 						</div>
 						<p class="note"><b>Ücretsiz ve açık kaynak.</b> Ailenin film günlüğü kendi sunucunda kalır.</p>
 						<button class="pop-trigger" type="button" aria-live="polite">Patlamış mısırı patlat</button>

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -1303,7 +1303,9 @@
 			</button>
 			<nav class="nav-links" aria-label="Ana gezinme">
 				<a href="#story">Nasıl çalışır?</a><a href="#features">Aileler bunu neden kullanıyor?</a
-				><a class="nav-cta" href="https://demo.popcornvote.org">Canlı demoyu dene ↗</a><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Canlı demoyu dene ↗</a
+				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
 			</nav>
 		</header>
 		<main id="content">
@@ -1316,9 +1318,13 @@
 							Herkes film önerir ve aynı programa göre oy alır. Oylarını biriktir, favorini destekle ve bu gecenin kazananını Popcorn Vote seçsin.
 						</p>
 						<div class="hero-actions">
-							<a class="button" href="https://demo.popcornvote.org"
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 								>Canlı demoyu dene <span aria-hidden="true">↗</span></a
-							><a class="button alt" href="https://github.com/Stadicus/popcorn-vote"
+							><a
+								class="button alt"
+								href="https://github.com/Stadicus/popcorn-vote"
+								target="_blank"
+								rel="noreferrer"
 								>Popcorn Vote’u kendin barındır <span aria-hidden="true">↗</span></a
 							>
 						</div>
@@ -1540,7 +1546,7 @@
 					<p class="eyebrow">Bir sonraki film gecen burada başlıyor</p>
 					<h2>Adil seçim. Keyifli akşam.</h2>
 					<p>Popcorn Vote ücretsiz, açık kaynaklı ve kendi sunucunda çalışmaya hazırdır.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote"
+					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
 						>Kurulumu GitHub’da gör <span aria-hidden="true">↗</span></a
 					>
 				</div>
@@ -1552,7 +1558,11 @@
 					>Stadicus'tan bir aile projesi <span aria-hidden="true">·</span> MIT lisanslı</span
 				>
 				<div class="footer-actions">
-					<a class="footer-project-link" href="https://github.com/Stadicus/popcorn-vote"
+					<a
+						class="footer-project-link"
+						href="https://github.com/Stadicus/popcorn-vote"
+						target="_blank"
+						rel="noreferrer"
 						><svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true">
 							<path
 								d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.48-2.7-.95-2.7-.95-.36-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .68-.22 2.2.82A7.66 7.66 0 0 1 8 4.8c.68 0 1.36.09 2 .27 1.52-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.52.56.83 1.27.83 2.15 0 3.08-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
@@ -1563,7 +1573,12 @@
 				</div>
 			</div>
 			<div class="media-credits">
-				<a href="https://www.themoviedb.org" aria-label="The Movie Database (TMDB)">
+				<a
+					href="https://www.themoviedb.org"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="The Movie Database (TMDB)"
+				>
 					<img src="/assets/tmdb.svg" width="273" height="36" alt="TMDB" loading="lazy" />
 				</a>
 				<p>

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -1667,7 +1667,6 @@
 				document.querySelectorAll('[data-reveal]').forEach((story) => observer.observe(story));
 			} else document.querySelectorAll('[data-reveal]').forEach((story) => story.classList.add('is-visible'));
 		</script>
-	
 		<script>
 			document.querySelectorAll('[data-language]').forEach((link) =>
 				link.addEventListener('click', () => {


### PR DESCRIPTION
## Overview

- prominently links the live demo from the navigation and hero section
- keeps GitHub as the secondary entry point for self-hosting
- opens external destinations in new tabs so the marketing page remains available
- updates all nine localized generated pages
- cleans up existing whitespace differences in the website build

## Motivation

Visitors previously could not try the application directly from the marketing website. The new primary demo CTA shortens that path while keeping self-hosting and project documentation easy to find.

## Impact

The marketing website now takes families directly to the public demo. Existing internal page navigation stays in the same tab, while demo, GitHub, and TMDB links open in a new tab.

## Validation

- `node docs/website-src/generate.mjs --check`
- `npm run lint`
- `npm run check`
- link verification across all nine localized pages
- visual verification at 1440 × 1000 and 390 × 844 pixels
- local multireview gate with no Critical or Major findings
