### PR TITLE
Add dark mode to marketing website

### DIFF
--- a/docs/website-src/generate.mjs
+++ b/docs/website-src/generate.mjs
@@ -181,7 +181,8 @@ ${generatedMarker}
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="index, follow" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#0b1218" media="(prefers-color-scheme: dark)" />
 		<meta name="description" content="Choose your language for Popcorn Vote, the free, self-hosted family movie night voting app." />
 		<title>Popcorn Vote — Choose your language</title>
 		<link rel="canonical" href="https://popcornvote.org/" />
@@ -202,7 +203,7 @@ ${generatedMarker}
 		<meta name="twitter:image" content="https://popcornvote.org/assets/social-preview.png" />
 		<meta name="twitter:image:alt" content="Popcorn Vote preview with a popcorn bucket and voting symbols." />
 		<style>
-			:root { color-scheme: light; font-family: system-ui, sans-serif; color: #101923; background: #f7f4ed; }
+			:root { color-scheme: light dark; font-family: system-ui, sans-serif; color: #101923; background: #f7f4ed; }
 			body { min-height: 100vh; margin: 0; display: grid; place-items: center; }
 			main { width: min(680px, calc(100% - 2rem)); text-align: center; }
 			.mark { font-size: 4rem; }
@@ -212,6 +213,13 @@ ${generatedMarker}
 			a { min-height: 44px; display: inline-flex; align-items: center; padding: .5rem 1rem; border: 1px solid #c9c1b5; border-radius: 999px; color: inherit; background: #fffdf8; font-weight: 700; text-decoration: none; }
 			a:hover { border-color: #c75d09; }
 			a:focus-visible { outline: 3px solid #08736f; outline-offset: 3px; }
+			@media (prefers-color-scheme: dark) {
+				:root { color: #f4f0e7; background: #0b1218; }
+				p { color: #aeb9c3; }
+				a { border-color: #465663; background: #141e27; }
+				a:hover { border-color: #ffae57; }
+				a:focus-visible { outline-color: #69d4cd; }
+			}
 		</style>
 		<script>
 			(() => {

--- a/docs/website-src/index.html
+++ b/docs/website-src/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -68,6 +68,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -155,6 +166,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -163,7 +175,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -181,6 +291,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -194,8 +307,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -219,9 +332,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -250,11 +364,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -266,8 +386,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -278,6 +398,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -292,7 +453,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -330,10 +491,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -389,15 +550,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -406,7 +567,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -418,12 +579,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -477,7 +638,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -488,8 +649,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -519,7 +685,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -573,7 +739,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -581,7 +747,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -643,7 +809,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -656,14 +822,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -685,7 +851,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -708,7 +875,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -837,13 +1004,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -860,21 +1027,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -980,8 +1151,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1007,7 +1178,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1015,7 +1186,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1029,7 +1200,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1056,7 +1228,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1133,7 +1305,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1188,7 +1363,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1214,6 +1390,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1285,11 +1462,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Main navigation">
-				<a href="#story">How it works</a><a href="#features">Why families use it</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Try live demo ↗</a
-				>{{LANGUAGE_MENU}}
+				<a href="#story">How it works</a><a href="#features">Why families use it</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Try live demo ↗</a
+				>{{LANGUAGE_MENU}}<button class="theme-toggle" type="button" aria-label="Toggle color theme">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1492,7 +1673,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Self-hoster notes</p>
 						<h3 id="self-hosting-title">Small stack. Thoughtful defaults.</h3>
@@ -1537,7 +1720,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1553,7 +1736,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>A family project by Stadicus <span aria-hidden="true">·</span> MIT licensed</span
+					>A family project by Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>MIT licensed</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1587,6 +1777,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website-src/index.html
+++ b/docs/website-src/index.html
@@ -336,6 +336,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -375,6 +376,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -400,7 +402,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -416,6 +418,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1095,8 +1100,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1304,7 +1310,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1376,8 +1382,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1467,7 +1478,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Try live demo ↗</a
-				>{{LANGUAGE_MENU}}<button class="theme-toggle" type="button" aria-label="Toggle color theme">
+				>{{LANGUAGE_MENU}}<button class="theme-toggle" type="button" aria-label="Dark mode">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1678,7 +1689,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Self-hoster notes</p>
-						<h3 id="self-hosting-title">Small stack. Thoughtful defaults.</h3>
+						<h2 id="self-hosting-title">Small stack. Thoughtful defaults.</h2>
 						<p class="nerd-summary">
 							The setup stays deliberately boring, while the details that protect a family’s data get proper
 							attention.

--- a/docs/website-src/messages.json
+++ b/docs/website-src/messages.json
@@ -142,7 +142,8 @@
 			"The Popcorn Vote wheel of fortune resolving a tied vote",
 			"The winning film displayed on the Popcorn Vote Movie Night screen",
 			"Popcorn Vote TV mode showing the winning movie on a television-friendly screen",
-			"Try live demo"
+			"Try live demo",
+			"Toggle color theme"
 		],
 		"de": [
 			"Popcorn Vote ist eine kostenlose, selbst gehostete App für den Familienfilmabend. Schlagen Sie Filme vor, sammeln Sie Stimmen, lösen Sie Stimmengleichheit mit einem Rad auf und führen Sie ein gemeinsames Filmtagebuch.",
@@ -228,7 +229,8 @@
 			"Das Popcorn Vote-Glücksrad entscheidet über eine Stimmengleichheit",
 			"Der Gewinnerfilm wird auf dem Bildschirm „PV⟧ Movie Night“ angezeigt",
 			"Popcorn Vote TV-Modus, der den Gewinnerfilm auf einem fernsehfreundlichen Bildschirm zeigt",
-			"Live-Demo testen"
+			"Live-Demo testen",
+			"Farbschema wechseln"
 		],
 		"es": [
 			"Popcorn Vote es una aplicación gratuita y autohospedada para una noche de cine familiar. Sugiera películas, acumule votos, resuelva empates con una rueda y lleve un diario cinematográfico compartido.",
@@ -314,7 +316,8 @@
 			"La rueda de la fortuna Popcorn Vote que resuelve un empate en la votación",
 			"La película ganadora se exhibirá en la pantalla Popcorn Vote Movie Night",
 			"Popcorn Vote Modo TV que muestra la película ganadora en una pantalla compatible con televisión",
-			"Probar la demo en vivo"
+			"Probar la demo en vivo",
+			"Cambiar el tema de color"
 		],
 		"fr": [
 			"Popcorn Vote est une application gratuite et auto-hébergée pour une soirée cinéma en famille. Suggérez des films, accumulez des votes, résolvez les votes à égalité avec une roue et tenez un journal de film partagé.",
@@ -400,7 +403,8 @@
 			"La roue de la fortune Popcorn Vote résout un vote à égalité",
 			"Le film gagnant affiché sur l'écran Popcorn Vote Movie Night",
 			"Mode TV Popcorn Vote montrant le film gagnant sur un écran compatible avec la télévision",
-			"Essayer la démo en direct"
+			"Essayer la démo en direct",
+			"Changer le thème de couleur"
 		],
 		"pt-BR": [
 			"Popcorn Vote é um aplicativo gratuito e auto-hospedado para noites de cinema em família. Sugira filmes, acumule votos, resolva votos empatados com uma roda e mantenha um diário de filmes compartilhado.",
@@ -486,7 +490,8 @@
 			"A roda da fortuna Popcorn Vote resolvendo uma votação empatada",
 			"O filme vencedor exibido na tela Popcorn Vote Movie Night",
 			"Popcorn Vote Modo TV mostrando o filme vencedor em uma tela adequada para televisão",
-			"Testar demonstração ao vivo"
+			"Testar demonstração ao vivo",
+			"Alternar tema de cores"
 		],
 		"it": [
 			"Popcorn Vote è un'app gratuita e self-hosted per serate di cinema in famiglia. Suggerisci film, accumula voti, risolvi i voti in parità con una ruota e tieni un diario cinematografico condiviso.",
@@ -572,7 +577,8 @@
 			"La ruota della fortuna Popcorn Vote risolve un voto in parità",
 			"Il film vincitore verrà visualizzato sullo schermo Popcorn Vote Movie Night",
 			"Popcorn Vote Modalità TV che mostra il film vincitore su uno schermo adatto alla televisione",
-			"Prova la demo online"
+			"Prova la demo online",
+			"Cambia il tema dei colori"
 		],
 		"pl": [
 			"Popcorn Vote to bezpłatna aplikacja hostowana na własnym serwerze, przeznaczona na rodzinny wieczór filmowy. Sugeruj filmy, zbieraj głosy, rozstrzygaj remisowe głosy za pomocą koła i prowadź wspólny dziennik filmowy.",
@@ -658,7 +664,8 @@
 			"Koło fortuny Popcorn Vote rozstrzygające remisową liczbę głosów",
 			"Zwycięski film wyświetlany na ekranie Nocy Filmowej Popcorn Vote",
 			"Popcorn Vote Tryb telewizyjny pokazujący zwycięski film na ekranie przyjaznym dla telewizji",
-			"Wypróbuj demo na żywo"
+			"Wypróbuj demo na żywo",
+			"Zmień motyw kolorystyczny"
 		],
 		"tr": [
 			"Popcorn Vote aile film geceleri için ücretsiz, kendi kendine barındırılan bir uygulamadır. Film önerin, oy toplayın, eşit oyları çarkla çözün ve ortak bir film günlüğü tutun.",
@@ -744,7 +751,8 @@
 			"Eşit oylu bir oyu çözen Popcorn Vote çarkıfelek",
 			"Kazanan film Popcorn Vote Film Gecesi ekranında gösteriliyor",
 			"Popcorn Vote Kazanan filmi televizyona uygun bir ekranda gösteren TV modu",
-			"Canlı demoyu dene"
+			"Canlı demoyu dene",
+			"Renk temasını değiştir"
 		],
 		"ja": [
 			"Popcorn Vote は、家族で映画鑑賞をするための無料の自己ホスト型アプリです。映画を提案し、投票を蓄積し、ホイールで同数の票を解決し、共有の映画日記を付けます。",
@@ -830,7 +838,8 @@
 			"同数票を解決するPopcorn Vote運命の輪",
 			"Popcorn Vote Movie Night スクリーンに表示される受賞作品",
 			"Popcorn Vote 受賞映画をテレビ向けの画面で表示する TV モード",
-			"ライブデモを試す"
+			"ライブデモを試す",
+			"カラーテーマを切り替える"
 		]
 	}
 }

--- a/docs/website-src/messages.json
+++ b/docs/website-src/messages.json
@@ -143,7 +143,7 @@
 			"The winning film displayed on the Popcorn Vote Movie Night screen",
 			"Popcorn Vote TV mode showing the winning movie on a television-friendly screen",
 			"Try live demo",
-			"Toggle color theme"
+			"Dark mode"
 		],
 		"de": [
 			"Popcorn Vote ist eine kostenlose, selbst gehostete App für den Familienfilmabend. Schlagen Sie Filme vor, sammeln Sie Stimmen, lösen Sie Stimmengleichheit mit einem Rad auf und führen Sie ein gemeinsames Filmtagebuch.",
@@ -230,7 +230,7 @@
 			"Der Gewinnerfilm wird auf dem Bildschirm „PV⟧ Movie Night“ angezeigt",
 			"Popcorn Vote TV-Modus, der den Gewinnerfilm auf einem fernsehfreundlichen Bildschirm zeigt",
 			"Live-Demo testen",
-			"Farbschema wechseln"
+			"Dunkelmodus"
 		],
 		"es": [
 			"Popcorn Vote es una aplicación gratuita y autohospedada para una noche de cine familiar. Sugiera películas, acumule votos, resuelva empates con una rueda y lleve un diario cinematográfico compartido.",
@@ -317,7 +317,7 @@
 			"La película ganadora se exhibirá en la pantalla Popcorn Vote Movie Night",
 			"Popcorn Vote Modo TV que muestra la película ganadora en una pantalla compatible con televisión",
 			"Probar la demo en vivo",
-			"Cambiar el tema de color"
+			"Modo oscuro"
 		],
 		"fr": [
 			"Popcorn Vote est une application gratuite et auto-hébergée pour une soirée cinéma en famille. Suggérez des films, accumulez des votes, résolvez les votes à égalité avec une roue et tenez un journal de film partagé.",
@@ -404,7 +404,7 @@
 			"Le film gagnant affiché sur l'écran Popcorn Vote Movie Night",
 			"Mode TV Popcorn Vote montrant le film gagnant sur un écran compatible avec la télévision",
 			"Essayer la démo en direct",
-			"Changer le thème de couleur"
+			"Mode sombre"
 		],
 		"pt-BR": [
 			"Popcorn Vote é um aplicativo gratuito e auto-hospedado para noites de cinema em família. Sugira filmes, acumule votos, resolva votos empatados com uma roda e mantenha um diário de filmes compartilhado.",
@@ -491,7 +491,7 @@
 			"O filme vencedor exibido na tela Popcorn Vote Movie Night",
 			"Popcorn Vote Modo TV mostrando o filme vencedor em uma tela adequada para televisão",
 			"Testar demonstração ao vivo",
-			"Alternar tema de cores"
+			"Modo escuro"
 		],
 		"it": [
 			"Popcorn Vote è un'app gratuita e self-hosted per serate di cinema in famiglia. Suggerisci film, accumula voti, risolvi i voti in parità con una ruota e tieni un diario cinematografico condiviso.",
@@ -578,7 +578,7 @@
 			"Il film vincitore verrà visualizzato sullo schermo Popcorn Vote Movie Night",
 			"Popcorn Vote Modalità TV che mostra il film vincitore su uno schermo adatto alla televisione",
 			"Prova la demo online",
-			"Cambia il tema dei colori"
+			"Modalità scura"
 		],
 		"pl": [
 			"Popcorn Vote to bezpłatna aplikacja hostowana na własnym serwerze, przeznaczona na rodzinny wieczór filmowy. Sugeruj filmy, zbieraj głosy, rozstrzygaj remisowe głosy za pomocą koła i prowadź wspólny dziennik filmowy.",
@@ -665,7 +665,7 @@
 			"Zwycięski film wyświetlany na ekranie Nocy Filmowej Popcorn Vote",
 			"Popcorn Vote Tryb telewizyjny pokazujący zwycięski film na ekranie przyjaznym dla telewizji",
 			"Wypróbuj demo na żywo",
-			"Zmień motyw kolorystyczny"
+			"Tryb ciemny"
 		],
 		"tr": [
 			"Popcorn Vote aile film geceleri için ücretsiz, kendi kendine barındırılan bir uygulamadır. Film önerin, oy toplayın, eşit oyları çarkla çözün ve ortak bir film günlüğü tutun.",
@@ -752,7 +752,7 @@
 			"Kazanan film Popcorn Vote Film Gecesi ekranında gösteriliyor",
 			"Popcorn Vote Kazanan filmi televizyona uygun bir ekranda gösteren TV modu",
 			"Canlı demoyu dene",
-			"Renk temasını değiştir"
+			"Karanlık mod"
 		],
 		"ja": [
 			"Popcorn Vote は、家族で映画鑑賞をするための無料の自己ホスト型アプリです。映画を提案し、投票を蓄積し、ホイールで同数の票を解決し、共有の映画日記を付けます。",
@@ -839,7 +839,7 @@
 			"Popcorn Vote Movie Night スクリーンに表示される受賞作品",
 			"Popcorn Vote 受賞映画をテレビ向けの画面で表示する TV モード",
 			"ライブデモを試す",
-			"カラーテーマを切り替える"
+			"ダークモード"
 		]
 	}
 }

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Hauptnavigation">
-				<a href="#story">Wie es funktioniert</a><a href="#features">Warum Familien es nutzen</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Live-Demo testen ↗</a
-				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">Wie es funktioniert</a><a href="#features">Warum Familien es nutzen</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Live-Demo testen ↗</a
+				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Farbschema wechseln">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Hinweise für Selbsthoster</p>
 						<h3 id="self-hosting-title">Kleiner Stack. Durchdachte Standards.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Ein Familienprojekt von Stadicus <span aria-hidden="true">·</span> MIT-lizenziert</span
+					>Ein Familienprojekt von Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>MIT-lizenziert</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Live-Demo testen ↗</a
-				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Farbschema wechseln">
+				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Dunkelmodus">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Hinweise für Selbsthoster</p>
-						<h3 id="self-hosting-title">Kleiner Stack. Durchdachte Standards.</h3>
+						<h2 id="self-hosting-title">Kleiner Stack. Durchdachte Standards.</h2>
 						<p class="nerd-summary">
 							Die Einrichtung bleibt bewusst unkompliziert. Der Schutz der Familiendaten steckt in den Details.
 						</p>

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Main navigation">
-				<a href="#story">How it works</a><a href="#features">Why families use it</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Try live demo ↗</a
-				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">How it works</a><a href="#features">Why families use it</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Try live demo ↗</a
+				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Toggle color theme">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1509,7 +1690,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Self-hoster notes</p>
 						<h3 id="self-hosting-title">Small stack. Thoughtful defaults.</h3>
@@ -1554,7 +1737,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1570,7 +1753,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>A family project by Stadicus <span aria-hidden="true">·</span> MIT licensed</span
+					>A family project by Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>MIT licensed</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1604,6 +1794,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Try live demo ↗</a
-				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Toggle color theme">
+				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Dark mode">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1695,7 +1706,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Self-hoster notes</p>
-						<h3 id="self-hosting-title">Small stack. Thoughtful defaults.</h3>
+						<h2 id="self-hosting-title">Small stack. Thoughtful defaults.</h2>
 						<p class="nerd-summary">
 							The setup stays deliberately boring, while the details that protect a family’s data get proper
 							attention.

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Navegación principal">
-				<a href="#story">como funciona</a><a href="#features">Por qué las familias lo usan</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Probar la demo en vivo ↗</a
-				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">como funciona</a><a href="#features">Por qué las familias lo usan</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Probar la demo en vivo ↗</a
+				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Cambiar el tema de color">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notas para self-hosters</p>
 						<h3 id="self-hosting-title">Stack pequeño. Valores predeterminados bien pensados.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Un proyecto familiar de Stadicus <span aria-hidden="true">·</span> licencia MIT</span
+					>Un proyecto familiar de Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>licencia MIT</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Probar la demo en vivo ↗</a
-				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Cambiar el tema de color">
+				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modo oscuro">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notas para self-hosters</p>
-						<h3 id="self-hosting-title">Stack pequeño. Valores predeterminados bien pensados.</h3>
+						<h2 id="self-hosting-title">Stack pequeño. Valores predeterminados bien pensados.</h2>
 						<p class="nerd-summary">
 							La configuración sigue siendo deliberadamente aburrida, mientras que los detalles que protegen los datos de una familia reciben la atención adecuada.
 						</p>

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Essayer la démo en direct ↗</a
-				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Changer le thème de couleur">
+				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Mode sombre">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notes pour l’auto-hébergement</p>
-						<h3 id="self-hosting-title">Petite stack. Réglages par défaut réfléchis.</h3>
+						<h2 id="self-hosting-title">Petite stack. Réglages par défaut réfléchis.</h2>
 						<p class="nerd-summary">
 							La configuration reste délibérément ennuyeuse, tandis que les détails qui protègent les données d’une famille reçoivent l’attention voulue.
 						</p>

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Navigation principale">
-				<a href="#story">Comment ça marche</a><a href="#features">Pourquoi les familles l'utilisent</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Essayer la démo en direct ↗</a
-				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">Comment ça marche</a><a href="#features">Pourquoi les familles l'utilisent</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Essayer la démo en direct ↗</a
+				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Changer le thème de couleur">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notes pour l’auto-hébergement</p>
 						<h3 id="self-hosting-title">Petite stack. Réglages par défaut réfléchis.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Un projet familial signé Stadicus <span aria-hidden="true">·</span> Licence MIT</span
+					>Un projet familial signé Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>Licence MIT</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -5,7 +5,8 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="index, follow" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#0b1218" media="(prefers-color-scheme: dark)" />
 		<meta name="description" content="Choose your language for Popcorn Vote, the free, self-hosted family movie night voting app." />
 		<title>Popcorn Vote — Choose your language</title>
 		<link rel="canonical" href="https://popcornvote.org/" />
@@ -35,7 +36,7 @@
 		<meta name="twitter:image" content="https://popcornvote.org/assets/social-preview.png" />
 		<meta name="twitter:image:alt" content="Popcorn Vote preview with a popcorn bucket and voting symbols." />
 		<style>
-			:root { color-scheme: light; font-family: system-ui, sans-serif; color: #101923; background: #f7f4ed; }
+			:root { color-scheme: light dark; font-family: system-ui, sans-serif; color: #101923; background: #f7f4ed; }
 			body { min-height: 100vh; margin: 0; display: grid; place-items: center; }
 			main { width: min(680px, calc(100% - 2rem)); text-align: center; }
 			.mark { font-size: 4rem; }
@@ -45,6 +46,13 @@
 			a { min-height: 44px; display: inline-flex; align-items: center; padding: .5rem 1rem; border: 1px solid #c9c1b5; border-radius: 999px; color: inherit; background: #fffdf8; font-weight: 700; text-decoration: none; }
 			a:hover { border-color: #c75d09; }
 			a:focus-visible { outline: 3px solid #08736f; outline-offset: 3px; }
+			@media (prefers-color-scheme: dark) {
+				:root { color: #f4f0e7; background: #0b1218; }
+				p { color: #aeb9c3; }
+				a { border-color: #465663; background: #141e27; }
+				a:hover { border-color: #ffae57; }
+				a:focus-visible { outline-color: #69d4cd; }
+			}
 		</style>
 		<script>
 			(() => {

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Prova la demo online ↗</a
-				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Cambia il tema dei colori">
+				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modalità scura">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Note per il self-hosting</p>
-						<h3 id="self-hosting-title">Stack essenziale. Impostazioni predefinite ragionate.</h3>
+						<h2 id="self-hosting-title">Stack essenziale. Impostazioni predefinite ragionate.</h2>
 						<p class="nerd-summary">
 							La configurazione rimane volutamente noiosa, mentre i dettagli che proteggono i dati di una famiglia ricevono la giusta attenzione.
 						</p>

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Navigazione principale">
-				<a href="#story">Come funziona</a><a href="#features">Perché le famiglie lo usano</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Prova la demo online ↗</a
-				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">Come funziona</a><a href="#features">Perché le famiglie lo usano</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Prova la demo online ↗</a
+				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Cambia il tema dei colori">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Note per il self-hosting</p>
 						<h3 id="self-hosting-title">Stack essenziale. Impostazioni predefinite ragionate.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Un progetto familiare targato Stadicus <span aria-hidden="true">·</span> Licenza MIT</span
+					>Un progetto familiare targato Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>Licenza MIT</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="メインナビゲーション">
-				<a href="#story">仕組み</a><a href="#features">家族が利用する理由</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>ライブデモを試す ↗</a
-				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">仕組み</a><a href="#features">家族が利用する理由</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>ライブデモを試す ↗</a
+				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="カラーテーマを切り替える">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">セルフホスト向けメモ</p>
 						<h3 id="self-hosting-title">小さな構成。考え抜かれた初期設定。</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Stadicus による家族プロジェクト <span aria-hidden="true">·</span> MITライセンス取得済み</span
+					>Stadicus による家族プロジェクト <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>MITライセンス取得済み</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>ライブデモを試す ↗</a
-				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="カラーテーマを切り替える">
+				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="ダークモード">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">セルフホスト向けメモ</p>
-						<h3 id="self-hosting-title">小さな構成。考え抜かれた初期設定。</h3>
+						<h2 id="self-hosting-title">小さな構成。考え抜かれた初期設定。</h2>
 						<p class="nerd-summary">
 							設定は意図的に退屈なままですが、家族のデータを保護するための詳細には適切な注目が集まっています。
 						</p>

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Wypróbuj demo na żywo ↗</a
-				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Zmień motyw kolorystyczny">
+				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Tryb ciemny">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notatki dla self-hosterów</p>
-						<h3 id="self-hosting-title">Mały stos. Przemyślane ustawienia domyślne.</h3>
+						<h2 id="self-hosting-title">Mały stos. Przemyślane ustawienia domyślne.</h2>
 						<p class="nerd-summary">
 							Konfiguracja pozostaje celowo nudna, a szczegóły chroniące dane rodziny poświęcono należytej uwagi.
 						</p>

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Główna nawigacja">
-				<a href="#story">Jak to działa</a><a href="#features">Dlaczego rodziny z niego korzystają</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Wypróbuj demo na żywo ↗</a
-				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">Jak to działa</a><a href="#features">Dlaczego rodziny z niego korzystają</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Wypróbuj demo na żywo ↗</a
+				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Zmień motyw kolorystyczny">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notatki dla self-hosterów</p>
 						<h3 id="self-hosting-title">Mały stos. Przemyślane ustawienia domyślne.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Projekt rodzinny autorstwa Stadicusa <span aria-hidden="true">·</span> Licencja MIT</span
+					>Projekt rodzinny autorstwa Stadicusa <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>Licencja MIT</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Navegação principal">
-				<a href="#story">Como funciona</a><a href="#features">Por que as famílias usam</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Testar demonstração ao vivo ↗</a
-				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">Como funciona</a><a href="#features">Por que as famílias usam</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Testar demonstração ao vivo ↗</a
+				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Alternar tema de cores">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notas para self-hosters</p>
 						<h3 id="self-hosting-title">Stack enxuto. Padrões bem pensados.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Um projeto familiar da Stadicus <span aria-hidden="true">·</span> Licenciado pelo MIT</span
+					>Um projeto familiar da Stadicus <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>Licenciado pelo MIT</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Testar demonstração ao vivo ↗</a
-				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Alternar tema de cores">
+				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modo escuro">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Notas para self-hosters</p>
-						<h3 id="self-hosting-title">Stack enxuto. Padrões bem pensados.</h3>
+						<h2 id="self-hosting-title">Stack enxuto. Padrões bem pensados.</h2>
 						<p class="nerd-summary">
 							A configuração permanece deliberadamente enfadonha, enquanto os detalhes que protegem os dados de uma família recebem a devida atenção.
 						</p>

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffbe36" />
+		<meta name="theme-color" content="#f7f4ed" />
 		<meta
 			name="robots"
 			content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -85,6 +85,17 @@
 		/>
 		<script>
 			document.documentElement.classList.add('js');
+			try {
+				const theme = localStorage.getItem('pv_website_theme');
+				if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+			} catch {}
+			const explicitTheme = document.documentElement.dataset.theme;
+			const dark =
+				explicitTheme === 'dark' ||
+				(explicitTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document
+				.querySelector('meta[name="theme-color"]')
+				.setAttribute('content', dark ? '#0b1218' : '#f7f4ed');
 		</script>
 		<style>
 			@font-face {
@@ -172,6 +183,7 @@
 					U+A720-A7FF;
 			}
 			:root {
+				color-scheme: light;
 				--ink: #101923;
 				--paper: #f7f4ed;
 				--cream: #fffdf8;
@@ -180,7 +192,105 @@
 				--aqua: #08736f;
 				--coral: #ee4658;
 				--line: #e5ded2;
+				--muted: #59636c;
+				--nav-muted: #53606c;
+				--soft: #65717b;
+				--control-line: #b9b3a8;
+				--menu-hover: #efeae0;
+				--menu-active: #f3e4b6;
+				--menu-active-ink: #55451e;
+				--screen: #e9e5dd;
+				--screen-aqua: #eff5f3;
+				--feature-gold: #f3e4b6;
+				--feature-gold-line: #e6ce85;
+				--feature-gold-ink: #55451e;
+				--deep-panel: #101923;
+				--deep-panel-raised: #243342;
+				--on-deep: #fff;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #101923;
+				--button-ink: #fff;
+				--ticker-glow: rgb(255 190 54 / 0.14);
+				--video-bg: #ffbe36;
+				--video-ink: #101923;
+				--video-shadow: rgb(83 60 0 / 0.2);
+				--self-host-bg: #ece7dd;
+				--hero-glow: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
 				--shadow: 0 18px 50px rgb(16 25 35 / 0.12);
+			}
+			:root[data-theme='dark'] {
+				color-scheme: dark;
+				--ink: #f4f0e7;
+				--paper: #0b1218;
+				--cream: #141e27;
+				--orange: #ffae57;
+				--gold: #ffc44d;
+				--aqua: #69d4cd;
+				--coral: #ff6675;
+				--line: #2b3945;
+				--muted: #aeb9c3;
+				--nav-muted: #a8b4be;
+				--soft: #93a2ae;
+				--control-line: #465663;
+				--menu-hover: #202d38;
+				--menu-active: #3a321d;
+				--menu-active-ink: #ffe096;
+				--screen: #1b2731;
+				--screen-aqua: #142b2c;
+				--feature-gold: #302a1a;
+				--feature-gold-line: #594a24;
+				--feature-gold-ink: #eadcae;
+				--deep-panel: #080e14;
+				--deep-panel-raised: #1c2a36;
+				--on-deep: #f7f4ed;
+				--on-deep-muted: #b7c2cb;
+				--button-bg: #ffc44d;
+				--button-ink: #332500;
+				--ticker-glow: rgb(255 196 77 / 0.24);
+				--video-bg: #30270d;
+				--video-ink: #f4f0e7;
+				--video-shadow: rgb(0 0 0 / 0.45);
+				--self-host-bg: #101a22;
+				--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+				--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) {
+					color-scheme: dark;
+					--ink: #f4f0e7;
+					--paper: #0b1218;
+					--cream: #141e27;
+					--orange: #ffae57;
+					--gold: #ffc44d;
+					--aqua: #69d4cd;
+					--coral: #ff6675;
+					--line: #2b3945;
+					--muted: #aeb9c3;
+					--nav-muted: #a8b4be;
+					--soft: #93a2ae;
+					--control-line: #465663;
+					--menu-hover: #202d38;
+					--menu-active: #3a321d;
+					--menu-active-ink: #ffe096;
+					--screen: #1b2731;
+					--screen-aqua: #142b2c;
+					--feature-gold: #302a1a;
+					--feature-gold-line: #594a24;
+					--feature-gold-ink: #eadcae;
+					--deep-panel: #080e14;
+					--deep-panel-raised: #1c2a36;
+					--on-deep: #f7f4ed;
+					--on-deep-muted: #b7c2cb;
+					--button-bg: #ffc44d;
+					--button-ink: #332500;
+					--ticker-glow: rgb(255 196 77 / 0.24);
+					--video-bg: #30270d;
+					--video-ink: #f4f0e7;
+					--video-shadow: rgb(0 0 0 / 0.45);
+					--self-host-bg: #101a22;
+					--hero-glow: radial-gradient(circle, #6b5017 0 20%, #443715 21% 45%, transparent 46%);
+					--shadow: 0 18px 50px rgb(0 0 0 / 0.38);
+				}
 			}
 			* {
 				box-sizing: border-box;
@@ -198,6 +308,9 @@
 				font:
 					600 16px/1.6 'Nunito Sans',
 					sans-serif;
+				transition:
+					color 0.2s ease,
+					background-color 0.2s ease;
 			}
 			a {
 				color: inherit;
@@ -211,8 +324,8 @@
 				position: absolute;
 				left: 1rem;
 				top: -5rem;
-				background: var(--ink);
-				color: white;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				padding: 0.7rem 1rem;
 				z-index: 10;
 			}
@@ -236,9 +349,10 @@
 				margin-bottom: 0.6rem;
 			}
 			.nav {
-				display: flex;
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
-				justify-content: space-between;
+				gap: 1rem;
 				min-height: 82px;
 			}
 			.brand {
@@ -267,11 +381,17 @@
 				gap: clamp(0.75rem, 2vw, 1.4rem);
 				font-size: 0.86rem;
 			}
-			.nav-links a:not(.nav-cta) {
-				color: #53606c;
+			.nav-links a {
+				color: var(--nav-muted);
 			}
-			.nav-links a:not(.nav-cta):hover {
+			.nav-links a:hover {
 				color: var(--ink);
+			}
+			.nav-actions {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				gap: clamp(0.65rem, 1.4vw, 1rem);
 			}
 			.nav-cta,
 			.button {
@@ -283,8 +403,8 @@
 				padding: 0.7rem 1rem;
 				border: 0;
 				border-radius: 999px;
-				background: var(--ink);
-				color: #fff;
+				background: var(--button-bg);
+				color: var(--button-ink);
 				font-weight: 800;
 				box-shadow: 0 8px 18px rgb(16 25 35 / 0.15);
 				transition:
@@ -295,6 +415,47 @@
 			.button:hover {
 				transform: translateY(-2px);
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
+			}
+			.theme-toggle {
+				display: grid;
+				place-items: center;
+				width: 44px;
+				height: 44px;
+				flex: 0 0 auto;
+				padding: 0;
+				border: 1px solid var(--control-line);
+				border-radius: 50%;
+				background: var(--cream);
+				color: var(--ink);
+				cursor: pointer;
+				box-shadow: 0 4px 12px rgb(16 25 35 / 0.08);
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					background-color 0.2s ease;
+			}
+			.theme-toggle:hover {
+				border-color: var(--orange);
+				transform: rotate(-8deg);
+			}
+			.theme-toggle:focus-visible {
+				outline: 3px solid var(--aqua);
+				outline-offset: 3px;
+			}
+			.theme-toggle .sun,
+			:root[data-theme='dark'] .theme-toggle .moon {
+				display: none;
+			}
+			:root[data-theme='dark'] .theme-toggle .sun {
+				display: inline;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root:not([data-theme='light']) .theme-toggle .moon {
+					display: none;
+				}
+				:root:not([data-theme='light']) .theme-toggle .sun {
+					display: inline;
+				}
 			}
 			.hero {
 				position: relative;
@@ -309,7 +470,7 @@
 				height: 38rem;
 				right: -15rem;
 				top: -12rem;
-				background: radial-gradient(circle, #ffd871 0 20%, #ffca49 21% 45%, transparent 46%);
+				background: var(--hero-glow);
 				opacity: 0.62;
 			}
 			.hero-grid {
@@ -347,10 +508,10 @@
 				gap: 0.4rem;
 				min-height: 44px;
 				padding: 0.55rem 0.75rem;
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				border-radius: 999px;
 				background: var(--cream);
-				color: #45515d;
+				color: var(--nav-muted);
 				font:
 					500 0.72rem/1 'DM Mono',
 					monospace;
@@ -406,15 +567,15 @@
 			}
 			.language-options a:hover,
 			.language-options a:focus-visible {
-				background: #efeae0;
+				background: var(--menu-hover);
 			}
 			.language-options a[aria-current='page'] {
-				background: #f3e4b6;
-				color: #55451e;
+				background: var(--menu-active);
+				color: var(--menu-active-ink);
 				font-weight: 800;
 			}
 			.language-code {
-				color: #65717b;
+				color: var(--soft);
 				font:
 					500 0.63rem/1 'DM Mono',
 					monospace;
@@ -423,7 +584,7 @@
 			.lede {
 				max-width: 540px;
 				margin: 1.15rem 0 1.35rem;
-				color: #53606c;
+				color: var(--nav-muted);
 				font-size: 1.08rem;
 			}
 			.hero-actions {
@@ -435,12 +596,12 @@
 			.button.alt {
 				background: transparent;
 				color: var(--ink);
-				border: 1px solid #b9b3a8;
+				border: 1px solid var(--control-line);
 				box-shadow: none;
 			}
 			.note {
 				margin: 1.1rem 0 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.82rem;
 			}
 			.note b {
@@ -494,7 +655,7 @@
 				border: 0;
 				padding: 0.3rem 0;
 				background: transparent;
-				color: #59636c;
+				color: var(--muted);
 				cursor: pointer;
 				font:
 					500 0.78rem 'DM Mono',
@@ -505,8 +666,13 @@
 				color: var(--orange);
 			}
 			.stripe {
-				background: var(--ink);
-				color: var(--cream);
+				position: relative;
+				z-index: 1;
+				background: var(--deep-panel);
+				color: var(--on-deep);
+				box-shadow:
+					0 -9px 24px var(--ticker-glow),
+					0 9px 24px var(--ticker-glow);
 				overflow: hidden;
 			}
 			.stripe p {
@@ -536,7 +702,7 @@
 			.section-head p:last-child {
 				max-width: 540px;
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 1.06rem;
 			}
 			.journey {
@@ -590,7 +756,7 @@
 				font-size: clamp(2rem, 3.8vw, 3.5rem);
 			}
 			.story-copy p:last-child {
-				color: #59636c;
+				color: var(--muted);
 			}
 			.screen {
 				position: relative;
@@ -598,7 +764,7 @@
 				place-items: center;
 				min-height: 300px;
 				padding: 2rem;
-				background: #e9e5dd;
+				background: var(--screen);
 			}
 			.screen img {
 				width: auto;
@@ -660,7 +826,7 @@
 			}
 			.story:nth-child(2) .screen {
 				order: -1;
-				background: #eff5f3;
+				background: var(--screen-aqua);
 			}
 			.story:nth-child(3) .screen {
 				background: #101923;
@@ -673,14 +839,14 @@
 				margin-top: 1.4rem;
 				padding: clamp(1.5rem, 4vw, 3rem);
 				border-radius: 26px;
-				background: var(--ink);
-				color: white;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 			}
 			.tv-mode h3 {
 				font-size: clamp(2rem, 3.5vw, 3.25rem);
 			}
 			.tv-mode p:last-child {
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.tv-mode .eyebrow,
 			.closer .eyebrow {
@@ -702,7 +868,8 @@
 					0 0 44px rgb(255 190 54 / 0.14);
 			}
 			.video-section {
-				background: var(--gold);
+				background: var(--video-bg);
+				color: var(--video-ink);
 				padding: 7rem 0;
 			}
 			.video-layout {
@@ -725,7 +892,7 @@
 				display: block;
 				width: 100%;
 				height: auto;
-				box-shadow: 0 18px 38px rgb(83 60 0 / 0.2);
+				box-shadow: 0 18px 38px var(--video-shadow);
 			}
 			.demo-top {
 				display: flex;
@@ -854,13 +1021,13 @@
 				border: 1px solid var(--line);
 			}
 			.feature:nth-child(2) {
-				background: #f3e4b6;
-				border-color: #e6ce85;
+				background: var(--feature-gold);
+				border-color: var(--feature-gold-line);
 			}
 			.feature:nth-child(3) {
-				background: #243342;
-				border-color: #243342;
-				color: white;
+				background: var(--deep-panel-raised);
+				border-color: var(--deep-panel-raised);
+				color: var(--on-deep);
 			}
 			.feature .icon {
 				display: grid;
@@ -877,21 +1044,25 @@
 			}
 			.feature p {
 				margin: 0;
-				color: #59636c;
+				color: var(--muted);
 				font-size: 0.91rem;
 			}
 			.feature:nth-child(2) p {
-				color: #55451e;
+				color: var(--feature-gold-ink);
 			}
 			.feature:nth-child(3) p {
 				color: #c8d2dc;
+			}
+			.self-hosting-section {
+				padding: 7rem 0;
+				border-block: 1px solid var(--line);
+				background: var(--self-host-bg);
 			}
 			.nerd-panel {
 				position: relative;
 				display: grid;
 				grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
 				gap: clamp(2rem, 5vw, 5rem);
-				margin-top: 1rem;
 				padding: clamp(2rem, 5vw, 4rem);
 				overflow: hidden;
 				border: 1px solid #344353;
@@ -997,8 +1168,8 @@
 				position: relative;
 				overflow: hidden;
 				padding: 7rem 0;
-				background: var(--ink);
-				color: #fff;
+				background: var(--deep-panel);
+				color: var(--on-deep);
 				text-align: center;
 			}
 			.closer:before {
@@ -1024,7 +1195,7 @@
 			.closer p {
 				max-width: 550px;
 				margin: 1.5rem auto 2rem;
-				color: #b7c2cb;
+				color: var(--on-deep-muted);
 			}
 			.closer .button {
 				background: var(--gold);
@@ -1032,7 +1203,7 @@
 			}
 			.footer {
 				padding: 1.5rem 0;
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.8rem;
 			}
 			.footer-row {
@@ -1046,7 +1217,8 @@
 				flex-wrap: wrap;
 				gap: 0.35rem;
 			}
-			.footer-project-link {
+			.footer-project-link,
+			.footer-license-link {
 				display: inline-flex;
 				align-items: center;
 				gap: 0.4rem;
@@ -1073,7 +1245,7 @@
 				margin-top: 1.2rem;
 				padding-top: 1rem;
 				border-top: 1px solid var(--line);
-				color: #65717b;
+				color: var(--soft);
 				font-size: 0.67rem;
 				font-weight: 500;
 				line-height: 1.5;
@@ -1150,7 +1322,10 @@
 				}
 			}
 			@media (max-width: 900px) {
-				.nav-links > a:not(.nav-cta) {
+				.nav {
+					grid-template-columns: minmax(0, 1fr) auto;
+				}
+				.nav-links {
 					display: none;
 				}
 			}
@@ -1205,7 +1380,8 @@
 					min-height: auto;
 				}
 				.section,
-				.video-section {
+				.video-section,
+				.self-hosting-section {
 					padding: 4.6rem 0;
 				}
 				.section-head {
@@ -1231,6 +1407,7 @@
 				*:after {
 					animation-duration: 0.01ms !important;
 					animation-iteration-count: 1 !important;
+					transition-duration: 0.01ms !important;
 				}
 			}
 		</style>
@@ -1302,11 +1479,15 @@
 				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 			</button>
 			<nav class="nav-links" aria-label="Ana gezinme">
-				<a href="#story">Nasıl çalışır?</a><a href="#features">Aileler bunu neden kullanıyor?</a
-				><a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Canlı demoyu dene ↗</a
-				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details>
+				<a href="#story">Nasıl çalışır?</a><a href="#features">Aileler bunu neden kullanıyor?</a>
 			</nav>
+			<div class="nav-actions">
+				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+					>Canlı demoyu dene ↗</a
+				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Renk temasını değiştir">
+					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+				</button>
+			</div>
 		</header>
 		<main id="content">
 			<section class="hero" id="top">
@@ -1499,7 +1680,9 @@
 						</p>
 					</article>
 				</div>
-				<aside class="nerd-panel" aria-labelledby="self-hosting-title">
+			</section>
+			<section class="self-hosting-section" aria-labelledby="self-hosting-title">
+				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Self-hosting notları</p>
 						<h3 id="self-hosting-title">Küçük teknoloji yığını. Düşünülmüş varsayılanlar.</h3>
@@ -1539,7 +1722,7 @@
 							</p>
 						</article>
 					</div>
-				</aside>
+				</div>
 			</section>
 			<section class="closer">
 				<div class="shell">
@@ -1555,7 +1738,14 @@
 		<footer class="shell footer">
 			<div class="footer-row">
 				<span class="footer-note"
-					>Stadicus'tan bir aile projesi <span aria-hidden="true">·</span> MIT lisanslı</span
+					>Stadicus'tan bir aile projesi <span aria-hidden="true">·</span>
+					<a
+						class="footer-license-link"
+						href="https://github.com/Stadicus/popcorn-vote/blob/main/LICENSE"
+						target="_blank"
+						rel="noreferrer"
+						>MIT lisanslı</a
+					></span
 				>
 				<div class="footer-actions">
 					<a
@@ -1588,6 +1778,26 @@
 			</div>
 		</footer>
 		<script>
+			const themeToggle = document.querySelector('.theme-toggle');
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+			const syncTheme = () => {
+				const explicitTheme = document.documentElement.dataset.theme;
+				const dark = explicitTheme === 'dark' || (explicitTheme !== 'light' && systemTheme.matches);
+				themeToggle.setAttribute('aria-pressed', String(dark));
+				const paper = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+				document.querySelector('meta[name="theme-color"]').setAttribute('content', paper);
+			};
+			themeToggle.addEventListener('click', () => {
+				const dark = themeToggle.getAttribute('aria-pressed') === 'true';
+				const theme = dark ? 'light' : 'dark';
+				document.documentElement.dataset.theme = theme;
+				try {
+					localStorage.setItem('pv_website_theme', theme);
+				} catch {}
+				syncTheme();
+			});
+			systemTheme.addEventListener('change', syncTheme);
+			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -353,6 +353,7 @@
 				grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 				align-items: center;
 				gap: 1rem;
+				width: min(1400px, calc(100% - 2rem));
 				min-height: 82px;
 			}
 			.brand {
@@ -392,6 +393,7 @@
 				align-items: center;
 				justify-content: flex-end;
 				gap: clamp(0.65rem, 1.4vw, 1rem);
+				white-space: nowrap;
 			}
 			.nav-cta,
 			.button {
@@ -417,7 +419,7 @@
 				box-shadow: 0 11px 22px rgb(16 25 35 / 0.19);
 			}
 			.theme-toggle {
-				display: grid;
+				display: none;
 				place-items: center;
 				width: 44px;
 				height: 44px;
@@ -433,6 +435,9 @@
 					transform 0.18s ease,
 					border-color 0.18s ease,
 					background-color 0.2s ease;
+			}
+			.js .theme-toggle {
+				display: grid;
 			}
 			.theme-toggle:hover {
 				border-color: var(--orange);
@@ -1112,8 +1117,9 @@
 				background: var(--aqua);
 				box-shadow: 0 0 14px var(--aqua);
 			}
-			.nerd-panel h3 {
+			.nerd-panel h2 {
 				max-width: 390px;
+				margin: 0;
 				font-size: clamp(2.2rem, 4vw, 3.7rem);
 			}
 			.nerd-summary {
@@ -1321,7 +1327,7 @@
 					transform: scale(1.06) rotate(-1deg);
 				}
 			}
-			@media (max-width: 900px) {
+			@media (max-width: 1360px) {
 				.nav {
 					grid-template-columns: minmax(0, 1fr) auto;
 				}
@@ -1393,8 +1399,13 @@
 					flex-direction: column;
 				}
 			}
-			@media (max-width: 480px) {
+			@media (max-width: 720px) {
 				.nav-cta {
+					display: none;
+				}
+			}
+			@media (max-width: 480px) {
+				.nav .language-menu summary > span:nth-child(2) {
 					display: none;
 				}
 			}
@@ -1484,7 +1495,7 @@
 			<div class="nav-actions">
 				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
 					>Canlı demoyu dene ↗</a
-				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Renk temasını değiştir">
+				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Karanlık mod">
 					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
 				</button>
 			</div>
@@ -1685,7 +1696,7 @@
 				<div class="shell nerd-panel">
 					<div class="nerd-intro">
 						<p class="nerd-kicker">Self-hosting notları</p>
-						<h3 id="self-hosting-title">Küçük teknoloji yığını. Düşünülmüş varsayılanlar.</h3>
+						<h2 id="self-hosting-title">Küçük teknoloji yığını. Düşünülmüş varsayılanlar.</h2>
 						<p class="nerd-summary">
 							Bir ailenin verilerini koruyan ayrıntılar gereken ilgiyi çekerken, kurulum kasıtlı olarak sıkıcı olmaya devam ediyor.
 						</p>


### PR DESCRIPTION
## Summary

- add automatic and manually selectable dark mode to the static marketing website
- keep the localized header responsive and center its navigation on wide screens
- improve the ticker, video, self-hosting, and footer presentation for both themes
- regenerate all nine localized deployable pages and the language gateway

## Validation

- `node docs/website-src/generate.mjs --check`
- `npm run check`
- `npm run lint`
- Playwright responsive/theme smoke checks across all nine locales
- local multireview: clean (no Critical/Major findings)
