### PR TITLE
Reveal the marketing header on scroll-up and add demo CTAs

### DIFF
--- a/docs/website-src/index.html
+++ b/docs/website-src/index.html
@@ -282,7 +282,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -310,7 +310,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -330,6 +330,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -873,6 +897,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1174,7 +1201,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1189,6 +1216,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1396,6 +1434,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1468,19 +1509,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Skip to content</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Play the Popcorn Vote animation">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Main navigation">
-				<a href="#story">How it works</a><a href="#features">Why families use it</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Try live demo ↗</a
-				>{{LANGUAGE_MENU}}<button class="theme-toggle" type="button" aria-label="Dark mode">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Play the Popcorn Vote animation">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Main navigation">
+					<a href="#story">How it works</a><a href="#features">Why families use it</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Try live demo ↗</a
+					>{{LANGUAGE_MENU}}<button class="theme-toggle" type="button" aria-label="Dark mode">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1639,6 +1682,11 @@
 							<h2>From voting to the winner.</h2>
 						</div>
 						<p>Watch the real app evaluate the standings, settle a tie, and reveal what plays tonight.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Try live demo <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1738,9 +1786,17 @@
 					<p class="eyebrow">Your next movie night starts here</p>
 					<h2>Keep the choice fair. Keep the evening fun.</h2>
 					<p>Popcorn Vote is free, open source, and ready to run on your own server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>View setup on GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Try live demo <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>View setup on GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1809,6 +1865,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Zum Inhalt springen</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Popcorn-Vote-Animation abspielen">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Hauptnavigation">
-				<a href="#story">Wie es funktioniert</a><a href="#features">Warum Familien es nutzen</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Live-Demo testen ↗</a
-				><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Dunkelmodus">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Popcorn-Vote-Animation abspielen">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Hauptnavigation">
+					<a href="#story">Wie es funktioniert</a><a href="#features">Warum Familien es nutzen</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Live-Demo testen ↗</a
+					><details class="language-menu"><summary aria-label="Sprache wählen"><span aria-hidden="true">◎</span><span lang="de">Deutsch</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de" aria-current="page"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Dunkelmodus">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>Von der Abstimmung bis zum Gewinner.</h2>
 						</div>
 						<p>Erlebe, wie die App den Zwischenstand auswertet, ein Unentschieden löst und den Film für heute Abend enthüllt.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Live-Demo testen <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">Dein nächster Filmabend beginnt hier</p>
 					<h2>Fair entscheiden. Filmabend genießen.</h2>
 					<p>Popcorn Vote ist kostenlos, Open Source und startklar für deinen eigenen Server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Setup auf GitHub ansehen <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Live-Demo testen <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Setup auf GitHub ansehen <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Skip to content</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Play the Popcorn Vote animation">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Main navigation">
-				<a href="#story">How it works</a><a href="#features">Why families use it</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Try live demo ↗</a
-				><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Dark mode">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Play the Popcorn Vote animation">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Main navigation">
+					<a href="#story">How it works</a><a href="#features">Why families use it</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Try live demo ↗</a
+					><details class="language-menu"><summary aria-label="Choose language"><span aria-hidden="true">◎</span><span lang="en">English</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en" aria-current="page"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Dark mode">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1656,6 +1699,11 @@
 							<h2>From voting to the winner.</h2>
 						</div>
 						<p>Watch the real app evaluate the standings, settle a tie, and reveal what plays tonight.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Try live demo <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1755,9 +1803,17 @@
 					<p class="eyebrow">Your next movie night starts here</p>
 					<h2>Keep the choice fair. Keep the evening fun.</h2>
 					<p>Popcorn Vote is free, open source, and ready to run on your own server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>View setup on GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Try live demo <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>View setup on GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1826,6 +1882,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Saltar al contenido</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Reproduce la animación Popcorn Vote">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Navegación principal">
-				<a href="#story">como funciona</a><a href="#features">Por qué las familias lo usan</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Probar la demo en vivo ↗</a
-				><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modo oscuro">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Reproduce la animación Popcorn Vote">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Navegación principal">
+					<a href="#story">como funciona</a><a href="#features">Por qué las familias lo usan</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Probar la demo en vivo ↗</a
+					><details class="language-menu"><summary aria-label="Elegir idioma"><span aria-hidden="true">◎</span><span lang="es">Español</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es" aria-current="page"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modo oscuro">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>De la votación al ganador.</h2>
 						</div>
 						<p>Mira cómo la aplicación evalúa la clasificación, resuelve un empate y revela qué película toca esta noche.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Probar la demo en vivo <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">Tu próxima noche de cine comienza aquí</p>
 					<h2>Una elección justa. Una noche divertida.</h2>
 					<p>Popcorn Vote es gratuito, de código abierto y está listo para ejecutarse en tu propio servidor.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Ver configuración en GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Probar la demo en vivo <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Ver configuración en GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Passer au contenu</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Jouer l'animation Popcorn Vote">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Navigation principale">
-				<a href="#story">Comment ça marche</a><a href="#features">Pourquoi les familles l'utilisent</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Essayer la démo en direct ↗</a
-				><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Mode sombre">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Jouer l'animation Popcorn Vote">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Navigation principale">
+					<a href="#story">Comment ça marche</a><a href="#features">Pourquoi les familles l'utilisent</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Essayer la démo en direct ↗</a
+					><details class="language-menu"><summary aria-label="Choisir la langue"><span aria-hidden="true">◎</span><span lang="fr">Français</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr" aria-current="page"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Mode sombre">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>Du vote au gagnant.</h2>
 						</div>
 						<p>Regarde l’application évaluer le classement, régler une égalité et révéler le film de ce soir.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Essayer la démo en direct <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">Ta prochaine soirée cinéma commence ici</p>
 					<h2>Un choix équitable. Une soirée réussie.</h2>
 					<p>Popcorn Vote est gratuit, open source et prêt à fonctionner sur ton propre serveur.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Afficher la configuration sur GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Essayer la démo en direct <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Afficher la configuration sur GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Vai al contenuto</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Riproduci l'animazione Popcorn Vote">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Navigazione principale">
-				<a href="#story">Come funziona</a><a href="#features">Perché le famiglie lo usano</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Prova la demo online ↗</a
-				><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modalità scura">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Riproduci l'animazione Popcorn Vote">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Navigazione principale">
+					<a href="#story">Come funziona</a><a href="#features">Perché le famiglie lo usano</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Prova la demo online ↗</a
+					><details class="language-menu"><summary aria-label="Scegli la lingua"><span aria-hidden="true">◎</span><span lang="it">Italiano</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it" aria-current="page"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modalità scura">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>Dal voto al vincitore.</h2>
 						</div>
 						<p>Guarda l'app reale valutare la classifica, risolvere un voto in parità e rivelare cosa si gioca stasera.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Prova la demo online <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">La tua prossima serata al cinema inizia qui</p>
 					<h2>Una scelta equa. Una serata divertente.</h2>
 					<p>Popcorn Vote è gratuito, open source e pronto per essere eseguito sul tuo server.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Visualizza la configurazione su GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Prova la demo online <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Visualizza la configurazione su GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">コンテンツにスキップ</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Popcorn Vote アニメーションを再生する">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="メインナビゲーション">
-				<a href="#story">仕組み</a><a href="#features">家族が利用する理由</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>ライブデモを試す ↗</a
-				><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="ダークモード">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Popcorn Vote アニメーションを再生する">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="メインナビゲーション">
+					<a href="#story">仕組み</a><a href="#features">家族が利用する理由</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>ライブデモを試す ↗</a
+					><details class="language-menu"><summary aria-label="言語を選択"><span aria-hidden="true">◎</span><span lang="ja">日本語</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja" aria-current="page"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="ダークモード">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>投票から勝者まで。</h2>
 						</div>
 						<p>実際のアプリが順位を評価し、同数の投票を解決し、今夜何が行われるかを明らかにするのを見てください。</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>ライブデモを試す <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">次の映画の夜はここから始まります</p>
 					<h2>公平に選ぶ。楽しい夜を過ごす。</h2>
 					<p>Popcorn Vote は無料のオープンソースで、独自のサーバー上ですぐに実行できます。</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>GitHub でセットアップを表示する <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>ライブデモを試す <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>GitHub でセットアップを表示する <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Przejdź do treści</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Odtwórz animację Popcorn Vote">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Główna nawigacja">
-				<a href="#story">Jak to działa</a><a href="#features">Dlaczego rodziny z niego korzystają</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Wypróbuj demo na żywo ↗</a
-				><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Tryb ciemny">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Odtwórz animację Popcorn Vote">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Główna nawigacja">
+					<a href="#story">Jak to działa</a><a href="#features">Dlaczego rodziny z niego korzystają</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Wypróbuj demo na żywo ↗</a
+					><details class="language-menu"><summary aria-label="Wybierz język"><span aria-hidden="true">◎</span><span lang="pl">Polski</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl" aria-current="page"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Tryb ciemny">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>Od głosowania do zwycięzcy.</h2>
 						</div>
 						<p>Zobacz, jak prawdziwa aplikacja ocenia rankingi, rozstrzyga remis i ujawnia, co zostanie rozegrane dziś wieczorem.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Wypróbuj demo na żywo <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">Twój kolejny wieczór filmowy zaczyna się tutaj</p>
 					<h2>Uczciwy wybór. Udany wieczór.</h2>
 					<p>Popcorn Vote jest darmowym, otwartym oprogramowaniem gotowym do uruchomienia na twoim własnym serwerze.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Zobacz konfigurację w GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Wypróbuj demo na żywo <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Zobacz konfigurację w GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">Pular para o conteúdo</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Reproduza a animação Popcorn Vote">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Navegação principal">
-				<a href="#story">Como funciona</a><a href="#features">Por que as famílias usam</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Testar demonstração ao vivo ↗</a
-				><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modo escuro">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Reproduza a animação Popcorn Vote">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Navegação principal">
+					<a href="#story">Como funciona</a><a href="#features">Por que as famílias usam</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Testar demonstração ao vivo ↗</a
+					><details class="language-menu"><summary aria-label="Escolher idioma"><span aria-hidden="true">◎</span><span lang="pt-BR">Português (Brasil)</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR" aria-current="page"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Modo escuro">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>Da votação ao vencedor.</h2>
 						</div>
 						<p>Assista ao aplicativo real avaliar a classificação, resolver um empate na votação e revelar o que acontecerá esta noite.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Testar demonstração ao vivo <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">Sua próxima noite de cinema começa aqui</p>
 					<h2>Uma escolha justa. Uma noite divertida.</h2>
 					<p>Popcorn Vote é gratuito, de código aberto e pronto para ser executado em seu próprio servidor.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Veja a configuração no GitHub <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Testar demonstração ao vivo <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Veja a configuração no GitHub <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -299,7 +299,7 @@
 				scroll-behavior: smooth;
 			}
 			section[id] {
-				scroll-margin-top: 1.5rem;
+				scroll-margin-top: calc(82px + 1.5rem);
 			}
 			body {
 				margin: 0;
@@ -327,7 +327,7 @@
 				background: var(--button-bg);
 				color: var(--button-ink);
 				padding: 0.7rem 1rem;
-				z-index: 10;
+				z-index: 40;
 			}
 			.skip:focus {
 				top: 1rem;
@@ -347,6 +347,30 @@
 			}
 			.hero .eyebrow {
 				margin-bottom: 0.6rem;
+			}
+			.site-header {
+				position: sticky;
+				top: 0;
+				z-index: 30;
+				border-bottom: 1px solid transparent;
+				background: var(--paper);
+				background: color-mix(in srgb, var(--paper) 94%, transparent);
+				transform: translateY(0);
+				transition:
+					transform 0.2s ease,
+					border-color 0.2s ease,
+					box-shadow 0.2s ease;
+				backdrop-filter: blur(14px);
+			}
+			.site-header.is-scrolled {
+				border-color: var(--line);
+				box-shadow: 0 8px 24px rgb(16 25 35 / 0.08);
+			}
+			.site-header.is-hidden {
+				transform: translateY(calc(-100% - 1px));
+			}
+			.site-header.is-hidden:focus-within {
+				transform: translateY(0);
 			}
 			.nav {
 				display: grid;
@@ -890,6 +914,9 @@
 				max-width: 420px;
 				margin: 0;
 			}
+			.video-actions {
+				margin-top: 1.5rem;
+			}
 			.demo {
 				width: 100%;
 			}
@@ -1191,7 +1218,7 @@
 			}
 			.closer h2,
 			.closer p,
-			.closer .button {
+			.closer-actions {
 				position: relative;
 			}
 			.closer h2 {
@@ -1206,6 +1233,17 @@
 			.closer .button {
 				background: var(--gold);
 				color: #3a2b00;
+			}
+			.closer-actions {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 0.75rem;
+			}
+			.closer .button.alt {
+				border-color: #63717e;
+				background: transparent;
+				color: #fff;
 			}
 			.footer {
 				padding: 1.5rem 0;
@@ -1413,6 +1451,9 @@
 				html {
 					scroll-behavior: auto;
 				}
+				.site-header {
+					transition: none;
+				}
 				*,
 				*:before,
 				*:after {
@@ -1485,19 +1526,21 @@
 	</head>
 	<body>
 		<a class="skip" href="#content">İçeriğe atla</a>
-		<header class="shell nav">
-			<button class="brand" type="button" aria-label="Popcorn Vote animasyonunu oynat">
-				<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
-			</button>
-			<nav class="nav-links" aria-label="Ana gezinme">
-				<a href="#story">Nasıl çalışır?</a><a href="#features">Aileler bunu neden kullanıyor?</a>
-			</nav>
-			<div class="nav-actions">
-				<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
-					>Canlı demoyu dene ↗</a
-				><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Karanlık mod">
-					<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+		<header class="site-header">
+			<div class="shell nav">
+				<button class="brand" type="button" aria-label="Popcorn Vote animasyonunu oynat">
+					<span class="mark" aria-hidden="true">🍿</span> <span translate="no">Popcorn Vote</span>
 				</button>
+				<nav class="nav-links" aria-label="Ana gezinme">
+					<a href="#story">Nasıl çalışır?</a><a href="#features">Aileler bunu neden kullanıyor?</a>
+				</nav>
+				<div class="nav-actions">
+					<a class="nav-cta" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+						>Canlı demoyu dene ↗</a
+					><details class="language-menu"><summary aria-label="Dil seç"><span aria-hidden="true">◎</span><span lang="tr">Türkçe</span></summary><ul class="language-options"><li><a href="/en/" hreflang="en" lang="en" data-language="en"><span>English</span><span class="language-code">en</span></a></li><li><a href="/de/" hreflang="de" lang="de" data-language="de"><span>Deutsch</span><span class="language-code">de</span></a></li><li><a href="/es/" hreflang="es" lang="es" data-language="es"><span>Español</span><span class="language-code">es</span></a></li><li><a href="/fr/" hreflang="fr" lang="fr" data-language="fr"><span>Français</span><span class="language-code">fr</span></a></li><li><a href="/pt-br/" hreflang="pt-BR" lang="pt-BR" data-language="pt-BR"><span>Português (Brasil)</span><span class="language-code">pt-BR</span></a></li><li><a href="/it/" hreflang="it" lang="it" data-language="it"><span>Italiano</span><span class="language-code">it</span></a></li><li><a href="/pl/" hreflang="pl" lang="pl" data-language="pl"><span>Polski</span><span class="language-code">pl</span></a></li><li><a href="/tr/" hreflang="tr" lang="tr" data-language="tr" aria-current="page"><span>Türkçe</span><span class="language-code">tr</span></a></li><li><a href="/ja/" hreflang="ja" lang="ja" data-language="ja"><span>日本語</span><span class="language-code">ja</span></a></li></ul></details><button class="theme-toggle" type="button" aria-label="Karanlık mod">
+						<span class="moon" aria-hidden="true">☾</span><span class="sun" aria-hidden="true">☀</span>
+					</button>
+				</div>
 			</div>
 		</header>
 		<main id="content">
@@ -1648,6 +1691,11 @@
 							<h2>Oy vermekten kazanana.</h2>
 						</div>
 						<p>Uygulamanın sıralamayı değerlendirmesini, eşitliği çözmesini ve bu geceki filmi açıklamasını izle.</p>
+						<div class="video-actions">
+							<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+								>Canlı demoyu dene <span aria-hidden="true">↗</span></a
+							>
+						</div>
 					</div>
 					<div class="demo">
 						<video controls preload="metadata" poster="/assets/video-preview.png">
@@ -1740,9 +1788,17 @@
 					<p class="eyebrow">Bir sonraki film gecen burada başlıyor</p>
 					<h2>Adil seçim. Keyifli akşam.</h2>
 					<p>Popcorn Vote ücretsiz, açık kaynaklı ve kendi sunucunda çalışmaya hazırdır.</p>
-					<a class="button" href="https://github.com/Stadicus/popcorn-vote" target="_blank" rel="noreferrer"
-						>Kurulumu GitHub’da gör <span aria-hidden="true">↗</span></a
-					>
+					<div class="closer-actions">
+						<a class="button" href="https://demo.popcornvote.org" target="_blank" rel="noreferrer"
+							>Canlı demoyu dene <span aria-hidden="true">↗</span></a
+						><a
+							class="button alt"
+							href="https://github.com/Stadicus/popcorn-vote"
+							target="_blank"
+							rel="noreferrer"
+							>Kurulumu GitHub’da gör <span aria-hidden="true">↗</span></a
+						>
+					</div>
 				</div>
 			</section>
 		</main>
@@ -1810,6 +1866,30 @@
 			systemTheme.addEventListener('change', syncTheme);
 			syncTheme();
 			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const siteHeader = document.querySelector('.site-header');
+			let previousScrollY = Math.max(window.scrollY, 0);
+			let headerUpdatePending = false;
+			const updateHeader = () => {
+				const currentScrollY = Math.max(window.scrollY, 0);
+				siteHeader.classList.toggle('is-scrolled', currentScrollY > 0);
+				if (currentScrollY <= 8 || currentScrollY < previousScrollY) {
+					siteHeader.classList.remove('is-hidden');
+				} else if (currentScrollY > previousScrollY && currentScrollY > siteHeader.offsetHeight) {
+					siteHeader.classList.add('is-hidden');
+				}
+				previousScrollY = currentScrollY;
+				headerUpdatePending = false;
+			};
+			window.addEventListener(
+				'scroll',
+				() => {
+					if (headerUpdatePending) return;
+					headerUpdatePending = true;
+					requestAnimationFrame(updateHeader);
+				},
+				{ passive: true }
+			);
+			updateHeader();
 			function supernova(target, scale = 1, anchor = null) {
 				if (reducedMotion) return;
 				const rect = target.getBoundingClientRect();


### PR DESCRIPTION
## What changed

- The marketing header now hides while scrolling down and reappears on the first upward movement.
- Anchor navigation, keyboard focus, and `prefers-reduced-motion` remain supported.
- Two additional calls to action link directly to the live demo: one beside the product video and one in the closing section.
- The visual hierarchy remains intentional: the live demo is primary, while self-hosting is secondary.
- All nine localized static pages were regenerated from the shared source template.

## Why

The header previously occupied screen space throughout the page, while the live demo became difficult to reach after leaving the hero section. The direction-aware behavior creates more reading space when scrolling down, restores navigation immediately when scrolling up, and makes the demo accessible at relevant points farther down the page.

## Validation

- `node docs/website-src/generate.mjs --check`
- `npm run lint`
- `npm run check` (0 errors; 7 pre-existing warnings)
- Browser verification with Playwright at desktop and mobile viewport sizes
- Verified light and dark themes, both scroll directions, all four demo links, and the absence of horizontal overflow
