### PR TITLE
Require manual release triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,23 @@
 name: Release
 
-# Every successful CI run on main publishes the Docker image to the GitHub
-# Container Registry, tagged with the version from package.json and with latest:
+# Releases are started explicitly from the Actions UI. They publish the current
+# tip of main to the GitHub Container Registry, tagged with the version from
+# package.json and with latest:
 #   ghcr.io/<owner>/<repo>:<version> and :latest
 #
 # The build is laid out for several architectures: each is produced on its own
 # and without a tag, then they are united into a manifest list from which any
-# container service picks the matching one. For now only linux/amd64 is built .
-# why, is explained at the `build` job.
+# container service picks the matching architecture.
 #
-# If the version is new, the same run also creates the git tag `v<version>` and
-# the GitHub release, with the matching CHANGELOG section as its text. That used
-# to be a manual step afterwards, and it was easily forgotten.
-#
-# No `tags: ['v*']` trigger any more. It came from the time when tags were set by
-# hand . and it has become dangerous: a tag added later on an old commit would
-# have rebuilt `:latest` from there, and every installation tracking `:latest`
-# would have followed it back to that older state.
+# If the version is new, the same manually started run also creates the git tag
+# `v<version>` and the GitHub release, using the matching CHANGELOG section.
 on:
-  workflow_run:
-    workflows: [CI]
-    branches: [main]
-    types: [completed]
+  workflow_dispatch:
 
 # Two runs in a row must not overtake each other: otherwise the faster one would
 # create tag and release on its commit while the other built the image.
 concurrency:
-  group: release-main
+  group: release-manual
   cancel-in-progress: false
 
 jobs:
@@ -42,79 +33,56 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          # The first parent is enough to tell which files the successful main
-          # commit introduced, for both squash commits and merge commits.
-          fetch-depth: 2
+          ref: main
       - id: target
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          CI_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          if [ "$CI_CONCLUSION" != success ]; then
-            echo "::error::CI finished with conclusion '$CI_CONCLUSION'; release is blocked."
+          release_sha=$(git rev-parse HEAD)
+          main_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)
+          if [ "$release_sha" != "$main_sha" ]; then
+            echo "::error::$release_sha was checked out, but main is now $main_sha. Start the release again."
             exit 1
           fi
 
-          # The marketing website shares the repository but not the app's
-          # release lifecycle. It still gets the full CI run; a website-only
-          # commit simply stops here, before waiting for Security or building
-          # Docker images.
-          if git rev-parse "$CI_HEAD_SHA^1" > /dev/null 2>&1; then
-            scope=$(git diff-tree --no-commit-id --name-only -r -z "$CI_HEAD_SHA^1" "$CI_HEAD_SHA" | bash .github/release-scope.sh)
-            if [ "$scope" = website-only ]; then
-              echo "::notice::$CI_HEAD_SHA changes only the independent marketing website. No app release is built."
-              echo "publish=false" >> "$GITHUB_OUTPUT"
-              echo "release_sha=$CI_HEAD_SHA" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          main_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)
-          if [ "$CI_HEAD_SHA" != "$main_sha" ]; then
-            echo "::notice::$CI_HEAD_SHA passed CI, but main is now $main_sha. This release run is superseded."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "release_sha=$CI_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
+          # A manual click chooses when to publish, but it cannot bypass the
+          # quality gates for the exact commit being released.
           deadline=$((SECONDS + 1800))
-          while true; do
-            line=$(
-              gh api "repos/$GITHUB_REPOSITORY/actions/workflows/security.yml/runs?event=push&branch=main&head_sha=$CI_HEAD_SHA&per_page=1" \
-                --jq '.workflow_runs[] | [.status, (.conclusion // "")] | @tsv' |
-                head -n 1
-            )
-            if [ -n "$line" ]; then
-              read -r status conclusion <<< "$line"
-              if [ "$status" = completed ]; then
-                if [ "$conclusion" != success ]; then
-                  echo "::error::Security finished with conclusion '$conclusion'; release is blocked."
-                  exit 1
+          for workflow in ci.yml security.yml; do
+            while true; do
+              line=$(
+                gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs?event=push&branch=main&head_sha=$release_sha&per_page=1" \
+                  --jq '.workflow_runs[] | [.status, (.conclusion // "")] | @tsv' |
+                  head -n 1
+              )
+              if [ -n "$line" ]; then
+                read -r status conclusion <<< "$line"
+                if [ "$status" = completed ]; then
+                  if [ "$conclusion" != success ]; then
+                    echo "::error::$workflow finished with conclusion '$conclusion'; release is blocked."
+                    exit 1
+                  fi
+                  break
                 fi
-                break
               fi
-            fi
-            if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::error::Timed out waiting for Security to pass for $CI_HEAD_SHA."
-              exit 1
-            fi
-            sleep 20
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::Timed out waiting for $workflow to pass for $release_sha."
+                exit 1
+              fi
+              sleep 20
+            done
           done
 
           main_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)
-          if [ "$CI_HEAD_SHA" != "$main_sha" ]; then
-            echo "::notice::$CI_HEAD_SHA passed CI and Security, but main is now $main_sha. This release run is superseded."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "release_sha=$CI_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ "$release_sha" != "$main_sha" ]; then
+            echo "::error::main moved from $release_sha to $main_sha while checking the gates. Start the release again."
+            exit 1
           fi
 
           echo "publish=true" >> "$GITHUB_OUTPUT"
-          echo "release_sha=$CI_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
 
   # Before building, not after: a version bump without a CHANGELOG section should
   # prevent publication. If the check ran afterwards, `:latest` would already be in
@@ -303,9 +271,8 @@ jobs:
 
           # Only what really is the tip of main gets `:latest`.
           #
-          # The workflow_run trigger alone is not enough: an older CI run can
-          # finish after main has moved on. The gate skips those runs already;
-          # this remains as the last check before assigning the moving tag.
+          # Main can move after the manual run passed its gate. Check once more
+          # before assigning the moving tag.
           head_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)
           if [ "$head_sha" = "$RELEASE_SHA" ]; then
             echo "publish_candidate=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- replace the automatic post-CI `workflow_run` release trigger with `workflow_dispatch`
- always release the current tip of `main`
- retain exact-commit CI and Security gates before publication
- abort if `main` moves during gate checks or before image publication

## Why

Merging to `main` must not publish a Docker image, tag, or GitHub release automatically. Releases should happen only after an explicit action in the GitHub Actions UI.

## Validation

- `npm run verify`
- 435 tests
- lint and secret lint
- svelte-check: 0 errors
- production build and dependency audit