### PR TITLE
docs: finalize v1.1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 # Changelog
 
-## v1.1.0 Account settings
+## v1.1.0 Family setup and public website
 
-- Added browser-based first-run setup and administrator-managed user accounts
-  with individual PINs, roles and activation controls.
+- Added a multilingual first-run wizard for new installations. It configures
+  family members, one shared family PIN, voting rules, scheduling, viewing
+  sources, timezone, TMDB and optional OMDb keys, and movie-language defaults.
 - Added settings for the instance name, timezone and automatic session timeout,
   while keeping environment-managed values read-only.
 - Added server-enforced session expiry, safer atomic configuration updates and
-  a fail-closed setup gate for existing data stores.
-- Added complete setup and settings translations for all supported languages.
-- Existing sessions need to sign in once after updating because authenticated
-  cookies now carry a signed issue time.
+  a fail-closed setup gate that protects existing data stores.
+- Added immediate PIN validation with accessible error focus, responsive setup
+  styling and complete setup translations for all supported languages.
+- Added the multilingual Popcorn Vote website, live-demo entry points and a
+  media kit with reusable project assets.
+- Strengthened release, security and browser-test automation, including WebKit,
+  coverage reporting, CodeQL and multi-architecture container publishing.
+- Existing sessions need to enter the shared family PIN once after updating
+  because authenticated cookies now carry a signed issue time.
 
 ## v1.0.0 Initial release
 


### PR DESCRIPTION
## What changed

- replace the outdated account-based v1.1.0 notes with the shipped shared-family-PIN setup model
- document the multilingual website, media kit, security hardening and release automation added since v1.0.0

## Validation

- `.github/release-notes.sh 1.1.0`
- `.github/no-german-characters.sh`
- `npx prettier --check CHANGELOG.md`

This PR prepares the manually triggered v1.1.0 release.