### PR TITLE
CodeQL: scan the source, not the build output

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: Popcorn Vote
+
+# `build/` is compiled output: the bundler inlines dependency code there, so
+# scanning it reports findings in software this repository neither wrote nor can
+# change, and reports the application's own code a second time under a generated
+# filename. Every open alert except one came from that directory, which buries
+# the findings that matter under noise nobody can act on.
+paths-ignore:
+  - build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,5 +30,5 @@ jobs:
       - uses: github/codeql-action/init@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
         with:
           languages: javascript-typescript
-      - run: npm run build
+          config-file: ./.github/codeql/codeql-config.yml
       - uses: github/codeql-action/analyze@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4


### PR DESCRIPTION
## Why

Five of the six open code-scanning alerts pointed into `build/` — compiled output, into which the bundler inlines dependency code. That reports findings in software this repository neither wrote nor can change, and reports the application's own code a second time under a generated chunk name. Two alerts (`#56`, `#57`) even named the same line of the same file twice.

## What changes

- `npm run build` is dropped from the CodeQL job — for `javascript-typescript` CodeQL analyses the source directly and needs no build. Side effect: the job gets faster.
- A config file keeps `build/` out of scope should the directory ever reappear.

What remains is the code actually worth reviewing.

## On `#5` (`src/lib/server/keys.ts:37`)

The only alert in real source, and a false positive: `fingerprint()` hashes no password but the app's own TMDB/OMDb API key from the configuration, in order to recognise whether the same key was refused again. The hash is compared inside the process only, never logged, never served, never persisted. A deliberately slow hash would be wrong here — it would cost latency per request while protecting nothing, since there is no user input to compare against. Dismissed separately as a false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)