### PR TITLE
Unraid Community Applications Template

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,40 @@
+# App store packaging
+
+One package per store, kept next to the application rather than in separate
+repositories. Every package repeats the container's ports, volumes and
+environment variables, so they drift the moment `docker-compose.yml` changes and
+nobody remembers the copies. Here a single diff shows what has to follow.
+
+**Source of truth is `docker-compose.yml` in the repository root.** When it
+gains, loses or renames a variable, every package below has to be checked.
+
+| Directory | Store | How it ships |
+|---|---|---|
+| `unraid/` | Unraid Community Applications | CA scans this repository and reads the XML directly. Nothing is submitted anywhere; the file here *is* the package. |
+| `umbrel/` | Umbrel App Store | Pull request against `getumbrel/umbrel-apps`. What lives here is the source the PR is fed from. |
+| `casaos/` | CasaOS / ZimaOS | Pull request against `IceWhaleTech/CasaOS-AppStore`. Must be tested on a real CasaOS instance before submitting. |
+
+## Two rules every package follows
+
+**No `ADDRESS_HEADER`.** The root `docker-compose.yml` sets
+`ADDRESS_HEADER=x-forwarded-for`, which is right *behind a reverse proxy*: the
+app then reads the client address out of that header. App store installs are
+reached directly, and there the header is written by whoever is calling. Setting
+it would let anyone hand the app a fresh address on every request and walk
+straight through the brute-force brake on the PIN. Left unset, the app uses the
+real socket address, which is what an app store install needs. Whoever puts a
+proxy in front adds the variable themselves.
+
+**Nothing is required up front.** The app starts with no configuration at all
+and asks for PIN, members, both API keys and the languages in the browser. Keys
+are still offered as optional fields, because entering them beforehand is
+convenient, but no install is blocked on them. This is what Umbrel's app store
+standard asks for: understandable from the browser after install, with no shell
+and no file editing.
+
+## Checking a package after changing the container
+
+```sh
+grep -E '^\s+[A-Z_]+:' docker-compose.yml          # variables the container knows
+grep -o 'Target="[A-Z_]*"' packaging/unraid/*.xml  # variables the package sets
+```

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,29 +1,52 @@
 # App store packaging
 
 One package per store, kept next to the application rather than in separate
-repositories. Every package repeats the container's ports, volumes and
+repositories. Every package repeats the container's port, data path and
 environment variables, so they drift the moment `docker-compose.yml` changes and
-nobody remembers the copies. Here a single diff shows what has to follow.
+nobody remembers the copies. Here a single diff shows what has to follow, and
+`check.sh` fails when it does not.
 
 **Source of truth is `docker-compose.yml` in the repository root.** When it
-gains, loses or renames a variable, every package below has to be checked.
+gains, loses or renames a variable, or moves the port or the data path, every
+package below has to be checked.
 
-| Directory | Store | How it ships |
+| Directory | Store | Status |
 |---|---|---|
-| `unraid/` | Unraid Community Applications | CA scans this repository and reads the XML directly. Nothing is submitted anywhere; the file here *is* the package. |
-| `umbrel/` | Umbrel App Store | Pull request against `getumbrel/umbrel-apps`. What lives here is the source the PR is fed from. |
-| `casaos/` | CasaOS / ZimaOS | Pull request against `IceWhaleTech/CasaOS-AppStore`. Must be tested on a real CasaOS instance before submitting. |
+| `unraid/` | Unraid Community Applications | shipped |
+
+Umbrel (`getumbrel/umbrel-apps`) and CasaOS (`IceWhaleTech/CasaOS-AppStore`) are
+planned and not packaged yet. Both take the package as a pull request against
+the store's own repository; what would live here is the source those PRs are fed
+from. CasaOS additionally requires the package to be tested on a real CasaOS
+instance before submitting.
+
+## How the Unraid package reaches users
+
+Community Applications reads the XML out of this repository, so the file here
+*is* the package and updating it updates the listing. Getting into the CA
+catalogue in the first place is a separate, one-time step: the repository has to
+be submitted at `ca.unraid.net/submit`, where a scan validates the templates and
+a moderator reviews the entry. Only users who paste the raw repository URL into
+Unraid's Docker tab by hand can install it without that, and almost nobody finds
+an app that way.
+
+`unraid/ca_profile.xml` carries the maintainer profile CA shows next to the app.
+The convention places it at the root of the registered template repository, and
+whether CA finds it one directory down is the open question of this packaging —
+to be answered by the submission scan, not by guessing. If the scan does not see
+it, the file moves to the repository root; the template itself is unaffected
+either way.
 
 ## Two rules every package follows
 
-**No `ADDRESS_HEADER`.** The root `docker-compose.yml` sets
-`ADDRESS_HEADER=x-forwarded-for`, which is right *behind a reverse proxy*: the
-app then reads the client address out of that header. App store installs are
-reached directly, and there the header is written by whoever is calling. Setting
-it would let anyone hand the app a fresh address on every request and walk
-straight through the brute-force brake on the PIN. Left unset, the app uses the
-real socket address, which is what an app store install needs. Whoever puts a
-proxy in front adds the variable themselves.
+**No `ADDRESS_HEADER`.** The root `docker-compose.yml` offers
+`ADDRESS_HEADER=x-forwarded-for` (commented out), which is right *behind a
+reverse proxy*: the app then reads the client address out of that header. App
+store installs are reached directly, and there the header is written by whoever
+is calling. Setting it would let anyone hand the app a fresh address on every
+request and walk straight through the brute-force brake on the PIN. Left unset,
+the app uses the real socket address, which is what an app store install needs.
+Whoever puts a proxy in front adds the variable themselves.
 
 **Nothing is required up front.** The app starts with no configuration at all
 and asks for PIN, members, both API keys and the languages in the browser. Keys
@@ -32,9 +55,31 @@ convenient, but no install is blocked on them. This is what Umbrel's app store
 standard asks for: understandable from the browser after install, with no shell
 and no file editing.
 
-## Checking a package after changing the container
+## Checking a package
 
 ```sh
-grep -E '^\s+[A-Z_]+:' docker-compose.yml          # variables the container knows
-grep -o 'Target="[A-Z_]*"' packaging/unraid/*.xml  # variables the package sets
+bash packaging/check.sh         # static: names, port, data path, XML
+bash packaging/test-install.sh  # runs the container the way a store would
+```
+
+`check.sh` compares what the packages set against `docker-compose.yml` and the
+application source. It verifies exactly four things, and nothing beyond them:
+XML well-formedness, that every variable name a package sets is read somewhere
+in `src/`, that the port and data path match the compose file, and that no
+package sets `ADDRESS_HEADER`.
+
+`test-install.sh` needs Docker and no Unraid. It creates the data directory with
+the ownership a store would give it, starts the container as the package
+describes, and checks what somebody who clicked install actually gets: that it
+stays up, answers `/healthz`, reports healthy, lands on the setup wizard, can
+complete setup, then stops offering it, survives an update and a restart, works
+on another host port, and comes back from a copied data directory. Two runs may
+overlap; names, ports and temporary files carry the PID.
+
+Umbrel commonly runs on a Raspberry Pi, so the arm64 half of the image is worth
+the same attention:
+
+```sh
+docker run --privileged --rm tonistiigi/binfmt --install arm64
+PLATFORM=linux/arm64 bash packaging/test-install.sh
 ```

--- a/packaging/check.sh
+++ b/packaging/check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Checks the app store packages against the application they install.
+#
+# A package repeats ports, volumes and variable names that live somewhere else,
+# and nothing fails when a name drifts: the container simply ignores what it does
+# not know, and the setting silently has no effect. Run this after touching
+# docker-compose.yml, the packages, or any environment variable.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+fail=0
+note() { printf '  %-6s %s\n' "$1" "$2"; }
+
+echo "XML well-formedness"
+for f in packaging/*/*.xml; do
+	[ -e "$f" ] || continue
+	if python3 -c "import xml.dom.minidom,sys;xml.dom.minidom.parse(sys.argv[1])" "$f" 2>/dev/null; then
+		note OK "$f"
+	else
+		note FAIL "$f"; fail=1
+	fi
+done
+
+echo
+echo "Variable names known to the application"
+for f in packaging/*/*.xml; do
+	[ -e "$f" ] || continue
+	grep -o 'Target="[A-Z_][A-Z_]*"' "$f" | sed 's/Target="//;s/"//' | sort -u | while read -r v; do
+		# Searched across the whole server tree: LOG_LEVEL lives in log.ts, the
+		# PV_* ones in config.ts, so config.ts alone would report false misses.
+		if grep -rq -- "$v" src/ 2>/dev/null; then
+			note OK "$v"
+		else
+			note FAIL "$v is set by $f but read nowhere in src/"
+			echo "DRIFT" >> /tmp/pv-pkg-drift
+		fi
+	done
+done
+[ -f /tmp/pv-pkg-drift ] && { fail=1; rm -f /tmp/pv-pkg-drift; }
+
+echo
+echo "ADDRESS_HEADER must not be set by a package"
+# Right behind a reverse proxy, wrong for a direct install: the app would read
+# the client address from a header the caller writes, and the brute-force brake
+# on the PIN could be walked straight through.
+# Only package files, never the prose: this check and the README both name the
+# variable in order to explain why it is absent.
+hits=$(grep -rl 'ADDRESS_HEADER' packaging/*/ 2>/dev/null | tr '\n' ' ')
+if [ -n "$hits" ]; then
+	note FAIL "found in: $hits"
+	fail=1
+else
+	note OK "absent from all packages"
+fi
+
+echo
+[ "$fail" = 0 ] && echo "packages consistent" || echo "PACKAGE DRIFT — see FAIL above"
+exit "$fail"

--- a/packaging/check.sh
+++ b/packaging/check.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# Checks the app store packages against the application they install.
+# Checks the app store packages against the container they install.
 #
-# A package repeats ports, volumes and variable names that live somewhere else,
-# and nothing fails when a name drifts: the container simply ignores what it does
-# not know, and the setting silently has no effect. Run this after touching
-# docker-compose.yml, the packages, or any environment variable.
+# A package repeats the port, the data path and the variable names that live in
+# docker-compose.yml, and none of that fails loudly when it drifts: the
+# container ignores a variable it does not know, and a wrong port only produces
+# a link that does not answer. Run this after touching docker-compose.yml, the
+# packages, or any environment variable.
+#
+# What is verified is exactly what is printed below and nothing beyond it.
 set -uo pipefail
 cd "$(dirname "$0")/.."
 fail=0
@@ -16,34 +19,61 @@ for f in packaging/*/*.xml; do
 	if python3 -c "import xml.dom.minidom,sys;xml.dom.minidom.parse(sys.argv[1])" "$f" 2>/dev/null; then
 		note OK "$f"
 	else
-		note FAIL "$f"; fail=1
+		note FAIL "$f"
+		fail=1
 	fi
 done
 
 echo
 echo "Variable names known to the application"
+# A `while read` at the end of a pipe runs in a subshell, so `fail=1` set inside
+# it would be lost on the way out. An earlier version worked around that with a
+# marker file at a fixed path in /tmp, which let two runs at once hand each
+# other's verdict around. A here-string keeps the loop in this shell instead.
+targets=$(grep -ho 'Target="[A-Z_][A-Z_]*"' packaging/*/*.xml 2>/dev/null | sed 's/Target="//;s/"//' | sort -u)
+while read -r v; do
+	[ -n "$v" ] || continue
+	# Whole word: a substring match would accept PV_TIMEZONE merely because
+	# PV_TIMEZONE_OFFSET exists, which is the very drift being hunted here.
+	if grep -rqw -- "$v" src/ 2>/dev/null; then
+		note OK "$v"
+	else
+		note FAIL "$v is set by a package but read nowhere in src/"
+		fail=1
+	fi
+done <<<"$targets"
+
+echo
+echo "Port and data path match the container"
+# Both are hardcoded in the template and neither is a variable name, so the
+# check above would never notice them drifting apart from the compose file.
+compose_port=$(grep -oE "^[[:space:]]+- '[0-9]+:[0-9]+'" docker-compose.yml | grep -oE ":[0-9]+'" | tr -d ":'" | head -1)
+compose_path=$(grep -oE '^[[:space:]]+- popcorn-vote-data:/[a-z]+' docker-compose.yml | sed 's|.*:||' | head -1)
 for f in packaging/*/*.xml; do
 	[ -e "$f" ] || continue
-	grep -o 'Target="[A-Z_][A-Z_]*"' "$f" | sed 's/Target="//;s/"//' | sort -u | while read -r v; do
-		# Searched across the whole server tree: LOG_LEVEL lives in log.ts, the
-		# PV_* ones in config.ts, so config.ts alone would report false misses.
-		if grep -rq -- "$v" src/ 2>/dev/null; then
-			note OK "$v"
-		else
-			note FAIL "$v is set by $f but read nowhere in src/"
-			echo "DRIFT" >> /tmp/pv-pkg-drift
-		fi
-	done
+	grep -q '<Container' "$f" || continue
+	tmpl_port=$(grep -oE 'Type="Port"' "$f" >/dev/null 2>&1 && grep -oE 'Target="[0-9]+"' "$f" | grep -oE '[0-9]+' | head -1)
+	tmpl_path=$(grep -oE 'Target="/[a-z]+"' "$f" | sed 's/Target="//;s/"//' | head -1)
+	if [ -n "$compose_port" ] && [ "$tmpl_port" = "$compose_port" ]; then
+		note OK "port $tmpl_port matches docker-compose.yml"
+	else
+		note FAIL "$f uses port ${tmpl_port:-none}, docker-compose.yml uses ${compose_port:-none}"
+		fail=1
+	fi
+	if [ -n "$compose_path" ] && [ "$tmpl_path" = "$compose_path" ]; then
+		note OK "data path $tmpl_path matches docker-compose.yml"
+	else
+		note FAIL "$f mounts ${tmpl_path:-none}, docker-compose.yml uses ${compose_path:-none}"
+		fail=1
+	fi
 done
-[ -f /tmp/pv-pkg-drift ] && { fail=1; rm -f /tmp/pv-pkg-drift; }
 
 echo
 echo "ADDRESS_HEADER must not be set by a package"
 # Right behind a reverse proxy, wrong for a direct install: the app would read
 # the client address from a header the caller writes, and the brute-force brake
-# on the PIN could be walked straight through.
-# Only package files, never the prose: this check and the README both name the
-# variable in order to explain why it is absent.
+# on the PIN could be walked straight through. Only package files are searched;
+# this script and the README name the variable in order to explain its absence.
 hits=$(grep -rl 'ADDRESS_HEADER' packaging/*/ 2>/dev/null | tr '\n' ' ')
 if [ -n "$hits" ]; then
 	note FAIL "found in: $hits"

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -19,20 +19,28 @@ UIDGID=${UIDGID:-99:100}          # Unraid appdata default
 # `${EXTRA:-default}` would be wrong here — it fills in on empty as well.
 if [ -z "${EXTRA+isset}" ]; then EXTRA="--user 99:100"; fi   # what the template passes as ExtraParams
 IMAGE=${IMAGE:-ghcr.io/stadicus/popcorn-vote:latest}
+# Umbrel commonly runs on a Raspberry Pi, so the arm64 half of the image matters
+# as much as the amd64 one. Emulation makes every step roughly five times
+# slower, hence the generous waits above:
+#   docker run --privileged --rm tonistiigi/binfmt --install arm64
+#   PLATFORM=linux/arm64 bash packaging/test-install.sh
+PLATFORM=${PLATFORM:-}
+[ -n "$PLATFORM" ] && PLATFORM_ARG="--platform $PLATFORM" || PLATFORM_ARG=""
 fail=0
 
-cleanup() { docker rm -f "$NAME" >/dev/null 2>&1; docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1; rmdir "$DIR" 2>/dev/null; }
+cleanup() { docker rm -f "$NAME" "$NAME-alt" "$NAME-copy" >/dev/null 2>&1; docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1; rmdir "$DIR" 2>/dev/null; }
 trap cleanup EXIT
 
 echo "image:      $IMAGE"
 echo "data dir:   $DIR (owned $UIDGID, as an app store would create it)"
 echo "extra args: ${EXTRA:-<none>}"
+echo "platform:   ${PLATFORM:-native}"
 echo
 
 docker run --rm -v "$DIR":/x alpine chown "$UIDGID" /x >/dev/null 2>&1
 docker rm -f "$NAME" >/dev/null 2>&1
 # shellcheck disable=SC2086
-docker run -d --name "$NAME" $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
+docker run -d --name "$NAME" $PLATFORM_ARG $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
 
 for _ in $(seq 1 20); do
 	sleep 1
@@ -65,6 +73,113 @@ if [ "$fail" = 0 ]; then
 	# Written as the store's user, so the operator can back the directory up.
 	owner=$(docker run --rm -v "$DIR":/x alpine stat -c '%u:%g' /x/popcornvote.sqlite 2>/dev/null)
 	[ "$owner" = "${UIDGID/:/:}" ] && echo "  OK    database owned $owner" || { echo "  FAIL  database owned $owner, expected $UIDGID"; fail=1; }
+
+	# Stores show this state to their users, and compose can be told to wait for
+	# it, so an app that serves fine while reporting unhealthy is a real defect.
+	# It was one: the check asked for `localhost`, which also resolves to ::1
+	# inside the container while the server binds IPv4 only.
+	health=""
+	for _ in $(seq 1 24); do
+		sleep 5
+		health=$(docker inspect --format '{{.State.Health.Status}}' "$NAME" 2>/dev/null)
+		[ "$health" = "healthy" ] || [ "$health" = "unhealthy" ] && break
+	done
+	if [ "$health" = "healthy" ]; then
+		echo "  OK    docker health check reports healthy"
+	elif [ -z "$health" ]; then
+		echo "  OK    image defines no health check, nothing to report"
+	else
+		echo "  FAIL  docker health check reports $health"
+		docker inspect --format '{{(index .State.Health.Log 0).Output}}' "$NAME" 2>/dev/null | head -1
+		fail=1
+	fi
+fi
+
+
+# ---------------------------------------------------------------------------
+# Beyond the first start: what a store puts the container through afterwards.
+# ---------------------------------------------------------------------------
+if [ "$fail" = 0 ]; then
+	echo
+	echo "after the first start"
+
+	# Completing setup is the point of the whole package: if this fails, the
+	# install is a dead end no matter how cleanly the container came up.
+	setup=$(curl -s -o /tmp/pv-setup.json -w '%{http_code}' --max-time 20 \
+		-X POST "http://localhost:$PORT/api/setup" \
+		-H 'content-type: application/json' \
+		-d '{"title":"Test Family","pin":"1234","confirmPin":"1234","members":["Anna","Ben"],"sources":["Server"],"tokenAmount":1,"tokenCap":5,"tokenStart":3,"tokenWeekday":1,"tokenHour":18,"timezone":"Europe/Berlin","interfaceLanguage":"en","movieLanguage":"en-US","movieFallbackLanguage":"en-US","certificationCountry":"DE","trailerLanguages":["en-US"],"tmdbApiKey":"dummy-key-for-this-test-only","omdbApiKey":""}')
+	if [ "$setup" = "200" ]; then
+		echo "  OK    setup completes through the API ($setup)"
+	else
+		echo "  FAIL  setup answered $setup: $(head -c 200 /tmp/pv-setup.json)"; fail=1
+	fi
+
+	# Having been set up, the app must stop offering setup — otherwise a second
+	# visitor could walk in and configure it again.
+	after=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 15 "http://localhost:$PORT/")
+	case "$after" in
+		*/setup) echo "  FAIL  still lands on the setup wizard after setup"; fail=1 ;;
+		*)       echo "  OK    first run is over, no longer offers setup ($after)" ;;
+	esac
+
+	# An update replaces the container and keeps the directory. This is the one
+	# operation every user performs sooner or later, and the one that loses data
+	# when a package gets the volume wrong.
+	docker rm -f "$NAME" >/dev/null 2>&1
+	# shellcheck disable=SC2086
+	docker run -d --name "$NAME" $PLATFORM_ARG $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
+	for _ in $(seq 1 20); do
+		sleep 2
+		[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$PORT/healthz")" = "200" ] && break
+	done
+	survived=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 15 "http://localhost:$PORT/")
+	case "$survived" in
+		*/setup) echo "  FAIL  configuration lost when the container was replaced"; fail=1 ;;
+		*)       echo "  OK    survives replacing the container (an update)" ;;
+	esac
+
+	# SQLite keeps -wal and -shm beside the database. A hard restart has to leave
+	# a consistent file behind, not a half-written one.
+	docker restart "$NAME" >/dev/null 2>&1
+	for _ in $(seq 1 20); do
+		sleep 2
+		code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$PORT/healthz")
+		[ "$code" = "200" ] && break
+	done
+	[ "$code" = "200" ] && echo "  OK    survives a restart" || { echo "  FAIL  unhealthy after restart ($code)"; fail=1; }
+
+	# Stores let people pick their own host port, and nothing in the app may
+	# assume the one from the template.
+	docker rm -f "$NAME-alt" >/dev/null 2>&1
+	# shellcheck disable=SC2086
+	docker run -d --name "$NAME-alt" $PLATFORM_ARG $EXTRA -p 39997:3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
+	for _ in $(seq 1 20); do
+		sleep 2
+		alt=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:39997/healthz)
+		[ "$alt" = "200" ] && break
+	done
+	docker rm -f "$NAME-alt" >/dev/null 2>&1
+	[ "$alt" = "200" ] && echo "  OK    works on a different host port" || { echo "  FAIL  broken on a different host port ($alt)"; fail=1; }
+
+	# Unraid users back up appdata by copying it. A copy has to start elsewhere.
+	COPY=$(mktemp -d)
+	docker run --rm -v "$DIR":/from -v "$COPY":/to alpine sh -c 'cp -a /from/. /to/ && chown -R 99:100 /to' >/dev/null 2>&1
+	docker rm -f "$NAME-copy" >/dev/null 2>&1
+	# shellcheck disable=SC2086
+	docker run -d --name "$NAME-copy" $PLATFORM_ARG $EXTRA -p 39996:3000 -v "$COPY":/data "$IMAGE" >/dev/null 2>&1
+	for _ in $(seq 1 20); do
+		sleep 2
+		cp_url=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 5 http://localhost:39996/ 2>/dev/null)
+		[ -n "$cp_url" ] && [ "$cp_url" != "http://localhost:39996/" ] && break
+	done
+	case "$cp_url" in
+		*/setup) echo "  FAIL  a copied data directory comes up unconfigured"; fail=1 ;;
+		"")      echo "  FAIL  a copied data directory does not answer"; fail=1 ;;
+		*)       echo "  OK    a copied data directory keeps its configuration (backup restore)" ;;
+	esac
+	docker rm -f "$NAME-copy" >/dev/null 2>&1
+	docker run --rm -v "$COPY":/x alpine rm -rf /x/. >/dev/null 2>&1; rmdir "$COPY" 2>/dev/null
 fi
 
 echo

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -11,8 +11,17 @@
 #
 # Needs Docker. Nothing else, and no Unraid.
 set -uo pipefail
-NAME=pv-store-test
-PORT=${PORT:-3999}
+# Everything that could collide carries the PID. Two runs at once — an amd64
+# and an arm64 pass, or a rerun while the first is still in its health poll —
+# otherwise share container names and ports, and the EXIT trap of the one that
+# finishes first tears down the containers of the other.
+RUN=$$
+NAME=pv-store-test-$RUN
+PORT=${PORT:-$((3900 + RUN % 90))}
+ALT_PORT=$((4000 + RUN % 90))
+COPY_PORT=$((4100 + RUN % 90))
+PAGE=$(mktemp)
+SETUP_OUT=$(mktemp)
 DIR=$(mktemp -d)
 UIDGID=${UIDGID:-99:100}          # Unraid appdata default
 # Set but empty must stay empty: that is how the broken case is reproduced, so
@@ -28,7 +37,18 @@ PLATFORM=${PLATFORM:-}
 [ -n "$PLATFORM" ] && PLATFORM_ARG="--platform $PLATFORM" || PLATFORM_ARG=""
 fail=0
 
-cleanup() { docker rm -f "$NAME" "$NAME-alt" "$NAME-copy" >/dev/null 2>&1; docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1; rmdir "$DIR" 2>/dev/null; }
+cleanup() {
+	docker rm -f "$NAME" "$NAME-alt" "$NAME-copy" >/dev/null 2>&1
+	docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1
+	rmdir "$DIR" 2>/dev/null
+	# Declared later in the script, so it may not exist yet when a signal
+	# arrives; without this it survived every interrupted run.
+	if [ -n "${COPY:-}" ] && [ -d "${COPY:-}" ]; then
+		docker run --rm -v "$COPY":/x alpine rm -rf /x/. >/dev/null 2>&1
+		rmdir "$COPY" 2>/dev/null
+	fi
+	rm -f "$PAGE" "$SETUP_OUT"
+}
 trap cleanup EXIT
 
 echo "image:      $IMAGE"
@@ -40,11 +60,15 @@ echo
 docker run --rm -v "$DIR":/x alpine chown "$UIDGID" /x >/dev/null 2>&1
 docker rm -f "$NAME" >/dev/null 2>&1
 # shellcheck disable=SC2086
-docker run -d --name "$NAME" $PLATFORM_ARG $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
+if ! docker run -d --name "$NAME" $PLATFORM_ARG $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>"$SETUP_OUT"; then
+	echo "  FAIL  docker run refused the package's own arguments:"
+	sed 's/^/        /' "$SETUP_OUT"
+	exit 1
+fi
 
 for _ in $(seq 1 20); do
 	sleep 1
-	status=$(docker ps -a --filter "name=$NAME" --format '{{.Status}}')
+	status=$(docker ps -a --filter "name=^/${NAME}$" --format '{{.Status}}')
 	case "$status" in
 		Up*) break ;;
 		Restarting*|Exited*) break ;;
@@ -63,8 +87,8 @@ if [ "$fail" = 0 ]; then
 
 	# The whole point of an app store package: a browser lands on something
 	# actionable, with no shell and no file editing.
-	url=$(curl -sL -o /tmp/pv-store-page.html -w '%{url_effective}' --max-time 10 "http://localhost:$PORT/")
-	if grep -q 'setup-tmdb-key' /tmp/pv-store-page.html; then
+	url=$(curl -sL -o "$PAGE" -w '%{url_effective}' --max-time 10 "http://localhost:$PORT/")
+	if grep -q 'setup-tmdb-key' "$PAGE"; then
 		echo "  OK    first run lands on the setup wizard ($url)"
 	else
 		echo "  FAIL  no setup wizard at $url"; fail=1
@@ -72,26 +96,36 @@ if [ "$fail" = 0 ]; then
 
 	# Written as the store's user, so the operator can back the directory up.
 	owner=$(docker run --rm -v "$DIR":/x alpine stat -c '%u:%g' /x/popcornvote.sqlite 2>/dev/null)
-	[ "$owner" = "${UIDGID/:/:}" ] && echo "  OK    database owned $owner" || { echo "  FAIL  database owned $owner, expected $UIDGID"; fail=1; }
+	[ "$owner" = "$UIDGID" ] && echo "  OK    database owned $owner" || { echo "  FAIL  database owned $owner, expected $UIDGID"; fail=1; }
 
 	# Stores show this state to their users, and compose can be told to wait for
 	# it, so an app that serves fine while reporting unhealthy is a real defect.
 	# It was one: the check asked for `localhost`, which also resolves to ::1
 	# inside the container while the server binds IPv4 only.
-	health=""
-	for _ in $(seq 1 24); do
-		sleep 5
-		health=$(docker inspect --format '{{.State.Health.Status}}' "$NAME" 2>/dev/null)
-		[ "$health" = "healthy" ] || [ "$health" = "unhealthy" ] && break
-	done
-	if [ "$health" = "healthy" ]; then
-		echo "  OK    docker health check reports healthy"
-	elif [ -z "$health" ]; then
-		echo "  OK    image defines no health check, nothing to report"
+	# Asked once up front: an empty Health.Status means "no health check in the
+	# image" and "docker inspect just failed" alike, and reporting both as fine
+	# would pass a container that died between the checks above and this one.
+	if [ -z "$(docker inspect --format '{{if .State.Health}}yes{{end}}' "$NAME" 2>/dev/null)" ]; then
+		if docker inspect "$NAME" >/dev/null 2>&1; then
+			echo "  OK    image defines no health check, nothing to report"
+		else
+			echo "  FAIL  container disappeared before the health check could be read"
+			fail=1
+		fi
 	else
-		echo "  FAIL  docker health check reports $health"
-		docker inspect --format '{{(index .State.Health.Log 0).Output}}' "$NAME" 2>/dev/null | head -1
-		fail=1
+		health=""
+		for _ in $(seq 1 24); do
+			sleep 5
+			health=$(docker inspect --format '{{.State.Health.Status}}' "$NAME" 2>/dev/null)
+			[ "$health" = "healthy" ] || [ "$health" = "unhealthy" ] && break
+		done
+		if [ "$health" = "healthy" ]; then
+			echo "  OK    docker health check reports healthy"
+		else
+			echo "  FAIL  docker health check reports ${health:-nothing}"
+			docker inspect --format '{{(index .State.Health.Log 0).Output}}' "$NAME" 2>/dev/null | head -1
+			fail=1
+		fi
 	fi
 fi
 
@@ -105,14 +139,14 @@ if [ "$fail" = 0 ]; then
 
 	# Completing setup is the point of the whole package: if this fails, the
 	# install is a dead end no matter how cleanly the container came up.
-	setup=$(curl -s -o /tmp/pv-setup.json -w '%{http_code}' --max-time 20 \
+	setup=$(curl -s -o "$SETUP_OUT" -w '%{http_code}' --max-time 20 \
 		-X POST "http://localhost:$PORT/api/setup" \
 		-H 'content-type: application/json' \
 		-d '{"title":"Test Family","pin":"1234","confirmPin":"1234","members":["Anna","Ben"],"sources":["Server"],"tokenAmount":1,"tokenCap":5,"tokenStart":3,"tokenWeekday":1,"tokenHour":18,"timezone":"Europe/Berlin","interfaceLanguage":"en","movieLanguage":"en-US","movieFallbackLanguage":"en-US","certificationCountry":"DE","trailerLanguages":["en-US"],"tmdbApiKey":"dummy-key-for-this-test-only","omdbApiKey":""}')
 	if [ "$setup" = "200" ]; then
 		echo "  OK    setup completes through the API ($setup)"
 	else
-		echo "  FAIL  setup answered $setup: $(head -c 200 /tmp/pv-setup.json)"; fail=1
+		echo "  FAIL  setup answered $setup: $(head -c 200 "$SETUP_OUT")"; fail=1
 	fi
 
 	# Having been set up, the app must stop offering setup — otherwise a second
@@ -153,10 +187,10 @@ if [ "$fail" = 0 ]; then
 	# assume the one from the template.
 	docker rm -f "$NAME-alt" >/dev/null 2>&1
 	# shellcheck disable=SC2086
-	docker run -d --name "$NAME-alt" $PLATFORM_ARG $EXTRA -p 39997:3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
+	docker run -d --name "$NAME-alt" $PLATFORM_ARG $EXTRA -p "$ALT_PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
 	for _ in $(seq 1 20); do
 		sleep 2
-		alt=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:39997/healthz)
+		alt=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:$ALT_PORT/healthz)
 		[ "$alt" = "200" ] && break
 	done
 	docker rm -f "$NAME-alt" >/dev/null 2>&1
@@ -167,12 +201,15 @@ if [ "$fail" = 0 ]; then
 	docker run --rm -v "$DIR":/from -v "$COPY":/to alpine sh -c 'cp -a /from/. /to/ && chown -R 99:100 /to' >/dev/null 2>&1
 	docker rm -f "$NAME-copy" >/dev/null 2>&1
 	# shellcheck disable=SC2086
-	docker run -d --name "$NAME-copy" $PLATFORM_ARG $EXTRA -p 39996:3000 -v "$COPY":/data "$IMAGE" >/dev/null 2>&1
+	docker run -d --name "$NAME-copy" $PLATFORM_ARG $EXTRA -p "$COPY_PORT":3000 -v "$COPY":/data "$IMAGE" >/dev/null 2>&1
+	# Break on any answer at all and let the case below judge it. Breaking only
+	# on a redirect meant the success path, which serves / directly, never
+	# matched and every green run waited out the full loop.
 	for _ in $(seq 1 20); do
 		sleep 2
-		cp_url=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 5 http://localhost:39996/ 2>/dev/null)
-		[ -n "$cp_url" ] && [ "$cp_url" != "http://localhost:39996/" ] && break
+		[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$COPY_PORT/healthz" 2>/dev/null)" = "200" ] && break
 	done
+	cp_url=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 10 "http://localhost:$COPY_PORT/" 2>/dev/null)
 	case "$cp_url" in
 		*/setup) echo "  FAIL  a copied data directory comes up unconfigured"; fail=1 ;;
 		"")      echo "  FAIL  a copied data directory does not answer"; fail=1 ;;

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Installs the container the way an app store would, and checks that a person
+# who clicked "install" actually gets somewhere.
+#
+# The interesting part is not the app, it is the ownership. App stores bind-mount
+# a host directory they created themselves, and the image runs as the
+# unprivileged user `node`. Unraid creates appdata as nobody:users (99:100), so
+# without a matching --user the container cannot write its own data directory
+# and dies with EACCES /data/covers, restarting forever. That failure is
+# invisible in the XML and invisible in CI; only a real container shows it.
+#
+# Needs Docker. Nothing else, and no Unraid.
+set -uo pipefail
+NAME=pv-store-test
+PORT=${PORT:-3999}
+DIR=$(mktemp -d)
+UIDGID=${UIDGID:-99:100}          # Unraid appdata default
+# Set but empty must stay empty: that is how the broken case is reproduced, so
+# `${EXTRA:-default}` would be wrong here — it fills in on empty as well.
+if [ -z "${EXTRA+isset}" ]; then EXTRA="--user 99:100"; fi   # what the template passes as ExtraParams
+IMAGE=${IMAGE:-ghcr.io/stadicus/popcorn-vote:latest}
+fail=0
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1; docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1; rmdir "$DIR" 2>/dev/null; }
+trap cleanup EXIT
+
+echo "image:      $IMAGE"
+echo "data dir:   $DIR (owned $UIDGID, as an app store would create it)"
+echo "extra args: ${EXTRA:-<none>}"
+echo
+
+docker run --rm -v "$DIR":/x alpine chown "$UIDGID" /x >/dev/null 2>&1
+docker rm -f "$NAME" >/dev/null 2>&1
+# shellcheck disable=SC2086
+docker run -d --name "$NAME" $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
+
+for _ in $(seq 1 20); do
+	sleep 1
+	status=$(docker ps -a --filter "name=$NAME" --format '{{.Status}}')
+	case "$status" in
+		Up*) break ;;
+		Restarting*|Exited*) break ;;
+	esac
+done
+
+echo "container:  $status"
+case "$status" in
+	Up*) echo "  OK    running" ;;
+	*)   echo "  FAIL  not running"; docker logs "$NAME" 2>&1 | tail -6; fail=1 ;;
+esac
+
+if [ "$fail" = 0 ]; then
+	code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://localhost:$PORT/healthz")
+	[ "$code" = "200" ] && echo "  OK    /healthz 200" || { echo "  FAIL  /healthz $code"; fail=1; }
+
+	# The whole point of an app store package: a browser lands on something
+	# actionable, with no shell and no file editing.
+	url=$(curl -sL -o /tmp/pv-store-page.html -w '%{url_effective}' --max-time 10 "http://localhost:$PORT/")
+	if grep -q 'setup-tmdb-key' /tmp/pv-store-page.html; then
+		echo "  OK    first run lands on the setup wizard ($url)"
+	else
+		echo "  FAIL  no setup wizard at $url"; fail=1
+	fi
+
+	# Written as the store's user, so the operator can back the directory up.
+	owner=$(docker run --rm -v "$DIR":/x alpine stat -c '%u:%g' /x/popcornvote.sqlite 2>/dev/null)
+	[ "$owner" = "${UIDGID/:/:}" ] && echo "  OK    database owned $owner" || { echo "  FAIL  database owned $owner, expected $UIDGID"; fail=1; }
+fi
+
+echo
+[ "$fail" = 0 ] && echo "store install works" || echo "STORE INSTALL BROKEN"
+exit "$fail"

--- a/packaging/unraid/ca_profile.xml
+++ b/packaging/unraid/ca_profile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Maintainer>
+  <Icon>https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/static/icon-512.png</Icon>
+  <Profile>A family project, shared publicly so others can build it themselves.</Profile>
+  <WebPage>https://popcornvote.org</WebPage>
+</Maintainer>

--- a/packaging/unraid/popcorn-vote.xml
+++ b/packaging/unraid/popcorn-vote.xml
@@ -20,7 +20,12 @@
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/packaging/unraid/popcorn-vote.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/static/icon-512.png</Icon>
-  <ExtraParams/>
+  <!-- The image runs as the unprivileged user `node`, and Unraid creates
+       appdata directories as nobody:users (99:100). Without this the container
+       cannot write its own data directory and dies on start with
+       EACCES /data/covers, restarting forever. Verified by reproducing that
+       ownership locally: it fails without the flag and comes up with it. -->
+  <ExtraParams>--user 99:100</ExtraParams>
   <PostArgs/>
   <CPUset/>
   <DonateText/>

--- a/packaging/unraid/popcorn-vote.xml
+++ b/packaging/unraid/popcorn-vote.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>popcorn-vote</Name>
+  <Repository>ghcr.io/stadicus/popcorn-vote:latest</Repository>
+  <Registry>https://github.com/Stadicus/popcorn-vote/pkgs/container/popcorn-vote</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Stadicus/popcorn-vote/issues</Support>
+  <Project>https://popcornvote.org</Project>
+  <Overview>
+    Fair family movie night voting. Everyone suggests films, gets one vote a week and can save votes up, so a film only one person wants wins eventually too. Ties are settled by a wheel of fortune, and watched films go into a shared rated archive with star ratings.
+
+    Mobile-first and installable as a PWA. Nine interface languages. Film data, posters and trailers come from TMDB, IMDb ratings through OMDb; both services are free for private use and each needs its own key.
+
+    Everything is configured in the browser on first start: family PIN, members, both API keys and the languages. No configuration file to edit, no console needed.
+  </Overview>
+  <Category>MediaApp:Video Tools:Utilities</Category>
+  <WebUI>http://[IP]:[PORT:3000]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/packaging/unraid/popcorn-vote.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/static/icon-512.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DonateText/>
+  <DonateLink/>
+  <Config Name="WebUI Port" Target="3000" Default="3000" Mode="tcp" Description="Port the web interface listens on." Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+  <Config Name="Appdata" Target="/data" Default="/mnt/user/appdata/popcorn-vote" Mode="rw" Description="Database, downloaded posters and the nightly backups. This is the only thing worth backing up." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/popcorn-vote</Config>
+  <Config Name="TMDB API key" Target="TMDB_API_KEY" Default="" Mode="" Description="Free key from themoviedb.org, used for search, posters, descriptions and trailers. May be left empty here and entered in the browser during first-run setup instead." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="OMDb API key" Target="OMDB_API_KEY" Default="" Mode="" Description="Free key from omdbapi.com, used for the IMDb rating only. Optional. May also be entered during first-run setup." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Time zone" Target="PV_TIMEZONE" Default="Europe/Berlin" Mode="" Description="Decides when the weekly vote credit is handed out. Use your own zone, for example America/New_York." Type="Variable" Display="always" Required="false" Mask="false">Europe/Berlin</Config>
+  <Config Name="Family PIN" Target="PV_PIN" Default="" Mode="" Description="Four digits, shared by the whole family. Leave empty to set it in the browser on first start, which is the recommended way: a PIN entered here is stored in the container template in plain text." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Session timeout" Target="PV_SESSION_TIMEOUT" Default="" Mode="" Description="Seconds without activity before a device has to enter the PIN again. Default is one year, matching the trusted family tablet." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Log level" Target="LOG_LEVEL" Default="" Mode="" Description="error, warn, info or debug. Default is info." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+</Container>


### PR DESCRIPTION
First of the app store packages. Unraid comes first because Community Applications scans this repository and reads the XML directly — the package waits on no foreign maintainer, unlike Umbrel and CasaOS, which go in as pull requests against their stores.

## Monorepo instead of a separate repository

Every store package repeats the container's ports, volumes and variable names. Those copies drift the moment `docker-compose.yml` changes, and nobody remembers them. Kept here, one diff shows what has to follow. `packaging/README.md` records which package goes where.

## One security detail that departs from the compose file

The package deliberately sets **no `ADDRESS_HEADER`**, unlike the `docker-compose.yml` in the repository root.

Behind a reverse proxy the variable is right: the app then reads the client address out of the forwarded header. An app store install is reached **directly**, and there the header is written by whoever is calling. Set, it would let anyone hand out a fresh address on every request and walk straight through the brute-force brake on the PIN. Unset, the app uses the real socket address, which is what this installation path needs. Whoever puts a proxy in front adds the variable themselves.

(The same finding for the compose file itself is handled separately in #19.)

## Nothing is required up front

The app starts with no configuration at all and asks for PIN, members, both API keys and the languages in the browser. The template therefore insists only on a port and a data directory; the keys are offered as optional convenience. This is precisely what Umbrel's app store standard asks for — "understandable from the browser after install… without SSH, CLI access, log scraping, or manual file edits" — and Unraid users benefit from it just as much.

## `packaging/check.sh`

Checks what silently breaks otherwise:

- XML well-formedness
- every variable a package sets is read somewhere in `src/` — a typo in a name is **ignored by the container without a word**, the setting simply has no effect
- no package sets `ADDRESS_HEADER`

Tested against a deliberately introduced typo, not just against the passing case: `PV_TIMEZOEN` → exit 1, restored → exit 0.

## Still open

- The **live scan** at CA only works after merging, because `<TemplateURL>` points at `main`. That also settles the one question the documentation leaves open: whether the scanner finds XML in a subdirectory. If not, the fallback is a single XML in the repository root — still no second repository.
- `check.sh` is **not** wired into CI (`.github/workflows/` is an infrastructure path, your call).
- No full multireview on this state; verification was the XML parser, the variable cross-check against `src/`, and the counter-test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)