### PR TITLE
Fix the container health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 VOLUME /data
 EXPOSE 3000
 USER node
+# 127.0.0.1 rather than localhost: the server binds 0.0.0.0, which is IPv4 only,
+# while `localhost` also resolves to ::1 in the container and busybox wget tries
+# that first. The check then answers "connection refused" for an application
+# that is serving perfectly well, and every container reports unhealthy.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
-    CMD wget -qO- http://localhost:3000/healthz > /dev/null || exit 1
+    CMD wget -qO- http://127.0.0.1:3000/healthz > /dev/null || exit 1
 CMD ["node", "build/index.js"]


### PR DESCRIPTION
## Every container reported unhealthy

```
$ docker inspect --format '{{.State.Health.Status}}' popcorn-vote
unhealthy
$ curl -o /dev/null -w '%{http_code}' http://localhost:3000/healthz
200
```

The check asked for `http://localhost:3000/healthz`. Inside the container `localhost` resolves to `::1` as well as `127.0.0.1`, and busybox `wget` tries the IPv6 address first. The server binds `0.0.0.0`, which is IPv4 only, so the check got `connection refused` from an application that was answering every outside request with 200.

Verified from inside the container:

```
$ wget -qO- http://127.0.0.1:3000/healthz
{"status":"ok"}
$ netstat -ltn
tcp  0  0 0.0.0.0:3000  0.0.0.0:*  LISTEN
```

## Not store specific

Found while testing the Unraid package (#18), but reproduced with a **named volume and no extra flags** — `docker compose up` exactly as this repository documents it. It affects everyone.

What it cost:

- `docker ps` showing `(unhealthy)` permanently
- monitoring alerting on a perfectly healthy app
- `depends_on: condition: service_healthy` never satisfied
- `docker compose up --wait` running into its timeout
- app stores displaying the state to their users

## Verification

Both images built and run:

| health check target | result |
|---|---|
| `localhost` (before) | unhealthy after ~70s |
| `127.0.0.1` (after) | **healthy after ~5s** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)