### PR TITLE
Record what the CA submission scan reported

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -30,12 +30,25 @@ a moderator reviews the entry. Only users who paste the raw repository URL into
 Unraid's Docker tab by hand can install it without that, and almost nobody finds
 an app that way.
 
+### The `not_unraid_application` warning is expected
+
+CA scans **every** `*.xml` file in the repository and counts each one that is not
+an app template. This repository contains `docs/website/sitemap.xml`, the
+generated sitemap of the project website, so the scan reports
+`not_unraid_application: 1`. That is the warning working as intended, not a
+defect in the package: the scan passes with no hard errors, one valid app, and a
+pullable image.
+
+It cannot be removed while the packaging lives here. The sitemap has to keep its
+name for search engines and has to stay in the repository because the web server
+pulls it from there. Only a separate, template-only repository would silence it,
+which is the trade the monorepo deliberately makes. If the count ever rises,
+check whether a new XML file was added rather than assuming the package broke.
+
 `unraid/ca_profile.xml` carries the maintainer profile CA shows next to the app.
-The convention places it at the root of the registered template repository, and
-whether CA finds it one directory down is the open question of this packaging —
-to be answered by the submission scan, not by guessing. If the scan does not see
-it, the file moves to the repository root; the template itself is unaffected
-either way.
+Convention places it at the root of a template repository, but the submission
+scan finds it here as well: it reported "ca_profile.xml found and Profile
+content extracted" with the file at `packaging/unraid/`. No move needed.
 
 ## Two rules every package follows
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -23,12 +23,16 @@ instance before submitting.
 ## How the Unraid package reaches users
 
 Community Applications reads the XML out of this repository, so the file here
-*is* the package and updating it updates the listing. Getting into the CA
-catalogue in the first place is a separate, one-time step: the repository has to
-be submitted at `ca.unraid.net/submit`, where a scan validates the templates and
-a moderator reviews the entry. Only users who paste the raw repository URL into
-Unraid's Docker tab by hand can install it without that, and almost nobody finds
-an app that way.
+*is* the package: **updating it updates the listing, with nothing to submit
+again.** Getting into the CA catalogue was a separate, one-time step, and it is
+done — the repository was submitted at `ca.unraid.net/submit` on 2026-08-15 and
+auto-approved, so the app appears once the next CA build publishes. Without that
+submission only users who paste the raw repository URL into Unraid's Docker tab
+by hand could have installed it, and almost nobody finds an app that way.
+
+From here on the catalogue follows `main`. A change to `unraid/popcorn-vote.xml`
+reaches users on the next CA build, and a broken change reaches them just as
+fast — which is what `check.sh` and `test-install.sh` are for.
 
 ### The `not_unraid_application` warning is expected
 


### PR DESCRIPTION
The Unraid submission scan has run against `main`. Result:

```
Repository processing:   No hard errors.
Valid apps found:        1 Docker app
Repository overview:     ca_profile.xml found and Profile content extracted.
Template warnings:       not_unraid_application: 1
Docker images pullable:  All 1 image(s) are pullable.
```

## The open question is answered

The packaging README carried a caveat that `ca_profile.xml` might have to sit at the repository root, since convention places it there. The scan found it at `packaging/unraid/` and extracted the profile. Nothing moves; the guess is replaced by the result.

## The one warning is expected, and stays

CA scans **every** `*.xml` file in the repository and counts each one that is not an app template. This repository contains `docs/website/sitemap.xml` — valid XML, not a template — so the count is 1.

It cannot be removed while the packaging lives beside the application:

- the sitemap must keep its name for search engines
- it must stay in the repository, because the web server pulls it from there
- only a separate, template-only repository would silence it — the trade this monorepo layout deliberately makes

Nothing is broken: no hard errors, one valid app, image pullable. Documented rather than hidden, so a future scan report can be read correctly — if the count rises, a new XML file was added, and the package itself is not at fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)