### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v1.2.0 Reliable health, a safer default, and the first app store
+
+- Fixed the container health check, which reported every installation as
+  unhealthy while the application was serving requests normally. It asked for
+  `localhost`, which resolves to `::1` as well as `127.0.0.1` inside the
+  container, while the server listens on IPv4 only. `docker ps` showed
+  `(unhealthy)` permanently, monitoring alerted on a healthy app, and
+  `depends_on: condition: service_healthy` could never be satisfied.
+- Changed `ADDRESS_HEADER` to be off by default. It makes the app read the
+  client address from a forwarding header, which is right behind a reverse
+  proxy and wrong on a directly reachable installation, where the caller writes
+  that header and can pick the address the per-IP PIN brake counts against.
+  **Whoever runs the app behind a reverse proxy has to uncomment
+  `ADDRESS_HEADER` and `XFF_DEPTH` in `docker-compose.yml` after updating**,
+  otherwise every visitor counts as the proxy and the brake locks the whole
+  household out together. The app now logs at startup which of the two it is
+  doing.
+- Added an Unraid Community Applications package, so the app can be installed
+  from the Unraid app store. It lives in `packaging/` alongside a consistency
+  check and an install test that runs the container the way a store does.
+- Completed the ARM64 documentation: the ready-made image has been published for
+  `linux/amd64` and `linux/arm64` for a while, but one installation guide still
+  claimed otherwise and sent ARM and NAS owners into an unnecessary local build.
+- Added a star request to the project website and narrowed the CodeQL scan to
+  the source, which had been reporting findings in bundled dependency code.
+
 ## v1.1.0 Family setup and public website
 
 - Added a multilingual first-run wizard for new installations. It configures

--- a/e2e/movie-night.spec.ts
+++ b/e2e/movie-night.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+
+// The About page prints the version vite compiled in, which comes from
+// package.json. Read from the same file rather than repeating the number
+// here, where a release bump would turn a green test red for no reason.
+const { version } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+	version: string;
+};
 
 async function enterPin(page: Page) {
 	await page.goto('/');
@@ -310,7 +318,9 @@ test('the More page links to the project and carries its signature', async ({ pa
 	await expect(creditNote).toHaveCSS('text-align', 'center');
 
 	await expect(page.getByText('Made with ❤️ by Stadicus', { exact: true })).toBeVisible();
-	await expect(page.locator('.version')).toHaveText(/^Version 1\.1\.0\+[0-9a-f]{7}$/);
+	await expect(page.locator('.version')).toHaveText(
+		new RegExp(`^Version ${version.replace(/\./g, '\\.')}\\+[0-9a-f]{7}$`)
+	);
 });
 
 test('an unknown address lands on the error page', async ({ page }) => {

--- a/e2e/movie-night.spec.ts
+++ b/e2e/movie-night.spec.ts
@@ -318,9 +318,13 @@ test('the More page links to the project and carries its signature', async ({ pa
 	await expect(creditNote).toHaveCSS('text-align', 'center');
 
 	await expect(page.getByText('Made with ❤️ by Stadicus', { exact: true })).toBeVisible();
-	await expect(page.locator('.version')).toHaveText(
-		new RegExp(`^Version ${version.replace(/\./g, '\\.')}\\+[0-9a-f]{7}$`)
-	);
+	// Two assertions rather than one regex built from the version, which would
+	// mean escaping the version into a pattern. Together they are just as
+	// strict: the shape below only matches when the number starts right after
+	// "Version ", so the substring can only be the one package.json holds.
+	const printedVersion = page.locator('.version');
+	await expect(printedVersion).toHaveText(/^Version \d+\.\d+\.\d+\+[0-9a-f]{7}$/);
+	await expect(printedVersion).toContainText(`Version ${version}+`);
 });
 
 test('an unknown address lands on the error page', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "popcorn-vote",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "popcorn-vote",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"better-sqlite3": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "popcorn-vote",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"private": true,
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Cuts version 1.2.0 and writes the release notes for it.

The published `1.1.0` image still carries the broken health check, so every
installation running it reports `(unhealthy)` while serving requests normally.
App stores show container health to their users, which makes a fresh release
the prerequisite for pinning an image digest in the Umbrel package.

Contents of the release, all already merged to `main`:

- the health check fix (#20)
- `ADDRESS_HEADER` off by default plus a startup notice (#19)
- the Unraid Community Applications package (#18)
- the ARM64 documentation correction and the website star request

The changelog carries a bold upgrade instruction for the `ADDRESS_HEADER`
change, because anyone running behind a reverse proxy has to uncomment two
lines in `docker-compose.yml` after updating.

After merge, `release.yml` gets triggered manually to build and publish
`ghcr.io/stadicus/popcorn-vote:1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)