### PR TITLE
Umbrel App Store package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ dist/
 # The template belongs in the repository, or the line above swallows it
 !.env.example
 data/
+# ...except the Umbrel package's bind-mount source. Umbrel expects the
+# directory to exist in the repository, and the rule above would drop it
+# without a word: git never descends into an ignored directory, so a fresh
+# clone would carry a package the store rejects.
+!packaging/umbrel/data/
 *.sqlite
 *.sqlite-*
 vite.config.ts.timestamp-*

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,8 @@ docs/website/
 # Working copies of the review subagents
 .claude/
 CLAUDE-SECURITY-*/
+
+# The store owns the style here, not this repository. Prettier would rewrite the
+# double quotes the whole Umbrel catalogue uses into single ones, and these two
+# files have to stay byte-identical to the ones in the submission pull request.
+packaging/umbrel/

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,12 +13,12 @@ package below has to be checked.
 | Directory | Store | Status |
 |---|---|---|
 | `unraid/` | Unraid Community Applications | shipped |
+| `umbrel/` | Umbrel App Store | submitted |
 
-Umbrel (`getumbrel/umbrel-apps`) and CasaOS (`IceWhaleTech/CasaOS-AppStore`) are
-planned and not packaged yet. Both take the package as a pull request against
-the store's own repository; what would live here is the source those PRs are fed
-from. CasaOS additionally requires the package to be tested on a real CasaOS
-instance before submitting.
+CasaOS (`IceWhaleTech/CasaOS-AppStore`) is planned and not packaged yet. It also
+takes the package as a pull request against the store's own repository, and
+additionally requires it to be tested on a real CasaOS instance before
+submitting.
 
 ## How the Unraid package reaches users
 
@@ -54,6 +54,37 @@ Convention places it at the root of a template repository, but the submission
 scan finds it here as well: it reported "ca_profile.xml found and Profile
 content extracted" with the file at `packaging/unraid/`. No move needed.
 
+## How the Umbrel package reaches users
+
+Umbrel keeps its catalogue in `getumbrel/umbrel-apps`, so unlike the Unraid
+template the two files here are only the *source* of the package. They reach
+users as a pull request against that repository, and **every later change needs
+another one** — nothing in this repository updates the listing.
+
+The image is pinned by digest, because a tag can be moved to a different image
+after the store reviewed it. Umbrel's own linter refuses `latest` for that
+reason. A release therefore runs in this order: publish the image, read the
+digest of the multi-arch index, then update `umbrel/docker-compose.yml`. The
+digest of a single architecture would leave everyone on the other one unable to
+install.
+
+`app_proxy` is the container Umbrel puts in front of every app. Two of its
+settings decide whether this one works at all:
+
+- `PROXY_AUTH_ADD: "false"` turns the Umbrel login off for this app, on purpose
+  and not for convenience. The family votes from their own phones, while the
+  Umbrel password belongs to whoever runs the server; leaving the login in front
+  would mean handing that password to the children.
+- `APP_HOST` has to be the container name Umbrel builds out of the app id,
+  `popcorn-vote_main_1`. Anything else and visitors get a blank page rather than
+  an error.
+
+The manifest's `port:` is the host port Umbrel reserves for the app, and it has
+to be free across the entire catalogue — not merely across the other `port:`
+fields, but across every port any app's compose file publishes. Checking only
+the manifests suggested 3009 was free; it is taken by a compose service, and
+3019 was chosen after collecting both.
+
 ## Two rules every package follows
 
 **No `ADDRESS_HEADER`.** The root `docker-compose.yml` offers
@@ -75,15 +106,19 @@ and no file editing.
 ## Checking a package
 
 ```sh
-bash packaging/check.sh         # static: names, port, data path, XML
+bash packaging/check.sh         # static: names, port, data path, XML, YAML
 bash packaging/test-install.sh  # runs the container the way a store would
 ```
 
 `check.sh` compares what the packages set against `docker-compose.yml` and the
-application source. It verifies exactly four things, and nothing beyond them:
-XML well-formedness, that every variable name a package sets is read somewhere
-in `src/`, that the port and data path match the compose file, and that no
-package sets `ADDRESS_HEADER`.
+application source. It verifies exactly this, and nothing beyond it: that the
+XML and the YAML parse, that every variable name a package sets is read
+somewhere in `src/`, that port and data path match the compose file, and that no
+package sets `ADDRESS_HEADER`. For the Umbrel package it additionally checks
+what only that store has: that the image is pinned to a digest, that its
+tag and the manifest version match `package.json`, that `APP_HOST` matches the
+app id, and that the data stays under `${APP_DATA_DIR}`, which is the only place
+Umbrel backs up and removes with the app.
 
 `test-install.sh` needs Docker and no Unraid. It creates the data directory with
 the ownership a store would give it, starts the container as the package
@@ -93,6 +128,14 @@ complete setup, then stops offering it, survives an update and a restart, works
 on another host port, and comes back from a copied data directory. Two runs may
 overlap; names, ports and temporary files carry the PID.
 
+The ownership is the point of the test, and the two stores do not agree on it:
+Unraid creates appdata as `99:100`, Umbrel as `1000:1000`. The defaults above are
+Unraid's, so the Umbrel package deserves its own pass:
+
+```sh
+UIDGID=1000:1000 EXTRA='--user 1000:1000' bash packaging/test-install.sh
+```
+
 Umbrel commonly runs on a Raspberry Pi, so the arm64 half of the image is worth
 the same attention:
 
@@ -100,3 +143,7 @@ the same attention:
 docker run --privileged --rm tonistiigi/binfmt --install arm64
 PLATFORM=linux/arm64 bash packaging/test-install.sh
 ```
+
+Emulation makes every step roughly five times slower, and `IMAGE=` picks which
+build is under test — a locally built `popcorn-vote:dev` before a release, the
+published digest after one.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,7 +13,7 @@ package below has to be checked.
 | Directory | Store | Status |
 |---|---|---|
 | `unraid/` | Unraid Community Applications | shipped |
-| `umbrel/` | Umbrel App Store | submitted |
+| `umbrel/` | Umbrel App Store | [submitted](https://github.com/getumbrel/umbrel-apps/pull/5994) |
 
 CasaOS (`IceWhaleTech/CasaOS-AppStore`) is planned and not packaged yet. It also
 takes the package as a pull request against the store's own repository, and

--- a/packaging/check.sh
+++ b/packaging/check.sh
@@ -69,6 +69,166 @@ for f in packaging/*/*.xml; do
 done
 
 echo
+echo "YAML well-formedness"
+have_yaml=0
+python3 -c "import yaml" 2>/dev/null && have_yaml=1
+if [ "$have_yaml" = 0 ]; then
+	note FAIL "python3 has no PyYAML, so no YAML package can be read (pip install pyyaml)"
+	fail=1
+else
+	for f in packaging/*/*.yml; do
+		[ -e "$f" ] || continue
+		if python3 -c "import yaml,sys;yaml.safe_load(open(sys.argv[1]))" "$f" 2>/dev/null; then
+			note OK "$f"
+		else
+			note FAIL "$f"
+			fail=1
+		fi
+	done
+fi
+
+echo
+echo "Umbrel package matches the container"
+# The Unraid template repeats port and path as XML attributes; the Umbrel
+# package repeats the same two facts across two YAML files, and adds two more
+# that only it has: a pinned image digest and the container name its proxy
+# resolves. None of them fail loudly either. A wrong APP_HOST gives the visitor
+# a blank page, an unpinned image gives them a different build than the one that
+# was reviewed.
+if [ ! -d packaging/umbrel ]; then
+	note SKIP "no packaging/umbrel directory"
+elif [ "$have_yaml" = 0 ]; then
+	note SKIP "needs PyYAML, see above"
+else
+	umbrel_facts=$(python3 - <<'PYTHON' 2>/dev/null
+import json, shlex, yaml
+
+manifest = yaml.safe_load(open('packaging/umbrel/umbrel-app.yml')) or {}
+compose = yaml.safe_load(open('packaging/umbrel/docker-compose.yml')) or {}
+package = json.load(open('package.json'))
+
+services = compose.get('services') or {}
+proxy = (services.get('app_proxy') or {}).get('environment') or {}
+main = services.get('main') or {}
+volumes = main.get('volumes') or []
+environment = main.get('environment') or {}
+if isinstance(environment, list):
+    environment = dict(e.split('=', 1) if '=' in e else (e, '') for e in environment)
+
+for key, value in [
+    ('u_id', manifest.get('id', '')),
+    ('u_version', manifest.get('version', '')),
+    ('u_app_host', proxy.get('APP_HOST', '')),
+    ('u_app_port', proxy.get('APP_PORT', '')),
+    ('u_image', main.get('image', '')),
+    ('u_mount', volumes[0] if volumes else ''),
+    ('u_env', ' '.join(sorted(environment))),
+    ('u_package_version', package.get('version', '')),
+]:
+    print(f'{key}={shlex.quote(str(value))}')
+PYTHON
+	)
+	if [ -z "$umbrel_facts" ]; then
+		note FAIL "packaging/umbrel could not be read"
+		fail=1
+	else
+		eval "$umbrel_facts"
+
+		if [ -n "$compose_port" ] && [ "$u_app_port" = "$compose_port" ]; then
+			note OK "APP_PORT $u_app_port matches docker-compose.yml"
+		else
+			note FAIL "APP_PORT is ${u_app_port:-none}, docker-compose.yml uses ${compose_port:-none}"
+			fail=1
+		fi
+
+		u_mount_target=${u_mount##*:}
+		u_mount_source=${u_mount%:*}
+		if [ -n "$compose_path" ] && [ "$u_mount_target" = "$compose_path" ]; then
+			note OK "data path $u_mount_target matches docker-compose.yml"
+		else
+			note FAIL "mounts ${u_mount_target:-none}, docker-compose.yml uses ${compose_path:-none}"
+			fail=1
+		fi
+
+		# Umbrel hands every app one directory under this variable and backs up
+		# and removes exactly that. An absolute path here would put the family's
+		# database outside all of it.
+		case $u_mount_source in
+		'${APP_DATA_DIR}'/*)
+			note OK 'data lives under ${APP_DATA_DIR}'
+			;;
+		*)
+			note FAIL "host side is ${u_mount_source:-none}, must start with \${APP_DATA_DIR}/"
+			fail=1
+			;;
+		esac
+
+		# Umbrel names containers <app id>_<service>_1, and the proxy in front
+		# resolves that name and nothing else.
+		if [ -n "$u_id" ] && [ "$u_app_host" = "${u_id}_main_1" ]; then
+			note OK "APP_HOST $u_app_host matches the app id"
+		else
+			note FAIL "APP_HOST is ${u_app_host:-none}, app id ${u_id:-none} makes it ${u_id:-?}_main_1"
+			fail=1
+		fi
+
+		# A tag can be moved to another image after the store reviewed it, a
+		# digest cannot.
+		case $u_image in
+		*@sha256:*) note OK "image is pinned to a digest" ;;
+		*)
+			note FAIL "image ${u_image:-none} is not pinned to a digest"
+			fail=1
+			;;
+		esac
+
+		u_image_ref=${u_image%%@*}
+		u_image_tag=${u_image_ref##*/}
+		case $u_image_tag in
+		*:*) u_image_tag=${u_image_tag##*:} ;;
+		*) u_image_tag="" ;;
+		esac
+		if [ -n "$u_image_tag" ] && [ "$u_image_tag" = "$u_package_version" ]; then
+			note OK "image tag $u_image_tag matches package.json"
+		else
+			note FAIL "image tag is ${u_image_tag:-none}, package.json says ${u_package_version:-none}"
+			fail=1
+		fi
+
+		if [ -n "$u_version" ] && [ "$u_version" = "$u_package_version" ]; then
+			note OK "manifest version $u_version matches package.json"
+		else
+			note FAIL "manifest version is ${u_version:-none}, package.json says ${u_package_version:-none}"
+			fail=1
+		fi
+
+		# Umbrel needs the bind-mount source to exist in the repository, and
+		# the root .gitignore has a `data/` rule that swallows it. Git never
+		# descends into an ignored directory, so the package looks complete
+		# here and arrives at the store one directory short.
+		if ! git -C . rev-parse --git-dir >/dev/null 2>&1; then
+			note SKIP "not a git checkout, cannot tell whether data/ is tracked"
+		elif git ls-files --error-unmatch packaging/umbrel/data >/dev/null 2>&1; then
+			note OK "the data directory is tracked by git"
+		else
+			note FAIL "packaging/umbrel/data/ is not tracked (the data/ rule in .gitignore)"
+			fail=1
+		fi
+
+		# Same rule the XML templates follow: whatever a package hands the
+		# container has to be a variable the application reads.
+		for v in $u_env; do
+			if grep -rqw -- "$v" src/ 2>/dev/null; then
+				note OK "$v"
+			else
+				note FAIL "$v is set by the Umbrel package but read nowhere in src/"
+				fail=1
+			fi
+		done
+	fi
+fi
+
+echo
 echo "ADDRESS_HEADER must not be set by a package"
 # Right behind a reverse proxy, wrong for a direct install: the app would read
 # the client address from a header the caller writes, and the brute-force brake

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -37,6 +37,21 @@ PLATFORM=${PLATFORM:-}
 [ -n "$PLATFORM" ] && PLATFORM_ARG="--platform $PLATFORM" || PLATFORM_ARG=""
 fail=0
 
+# `Up` only means docker started the process; the server binds a moment later.
+# On amd64 that moment is short enough to miss, under emulation it is not, and
+# the first start used to probe immediately while every later phase waited. That
+# reported a broken package for a perfectly good arm64 image. One helper now, so
+# the phases cannot drift apart again.
+wait_for_healthz() {   # wait_for_healthz <port>, echoes the last status code
+	local port=$1 code=000
+	for _ in $(seq 1 60); do
+		code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$port/healthz" 2>/dev/null)
+		[ "$code" = "200" ] && break
+		sleep 2
+	done
+	printf '%s' "$code"
+}
+
 cleanup() {
 	docker rm -f "$NAME" "$NAME-alt" "$NAME-copy" >/dev/null 2>&1
 	docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1
@@ -82,7 +97,7 @@ case "$status" in
 esac
 
 if [ "$fail" = 0 ]; then
-	code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://localhost:$PORT/healthz")
+	code=$(wait_for_healthz "$PORT")
 	[ "$code" = "200" ] && echo "  OK    /healthz 200" || { echo "  FAIL  /healthz $code"; fail=1; }
 
 	# The whole point of an app store package: a browser lands on something
@@ -163,10 +178,7 @@ if [ "$fail" = 0 ]; then
 	docker rm -f "$NAME" >/dev/null 2>&1
 	# shellcheck disable=SC2086
 	docker run -d --name "$NAME" $PLATFORM_ARG $EXTRA -p "$PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
-	for _ in $(seq 1 20); do
-		sleep 2
-		[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$PORT/healthz")" = "200" ] && break
-	done
+	wait_for_healthz "$PORT" >/dev/null
 	survived=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 15 "http://localhost:$PORT/")
 	case "$survived" in
 		*/setup) echo "  FAIL  configuration lost when the container was replaced"; fail=1 ;;
@@ -176,11 +188,7 @@ if [ "$fail" = 0 ]; then
 	# SQLite keeps -wal and -shm beside the database. A hard restart has to leave
 	# a consistent file behind, not a half-written one.
 	docker restart "$NAME" >/dev/null 2>&1
-	for _ in $(seq 1 20); do
-		sleep 2
-		code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$PORT/healthz")
-		[ "$code" = "200" ] && break
-	done
+	code=$(wait_for_healthz "$PORT")
 	[ "$code" = "200" ] && echo "  OK    survives a restart" || { echo "  FAIL  unhealthy after restart ($code)"; fail=1; }
 
 	# Stores let people pick their own host port, and nothing in the app may
@@ -188,11 +196,7 @@ if [ "$fail" = 0 ]; then
 	docker rm -f "$NAME-alt" >/dev/null 2>&1
 	# shellcheck disable=SC2086
 	docker run -d --name "$NAME-alt" $PLATFORM_ARG $EXTRA -p "$ALT_PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
-	for _ in $(seq 1 20); do
-		sleep 2
-		alt=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:$ALT_PORT/healthz)
-		[ "$alt" = "200" ] && break
-	done
+	alt=$(wait_for_healthz "$ALT_PORT")
 	docker rm -f "$NAME-alt" >/dev/null 2>&1
 	[ "$alt" = "200" ] && echo "  OK    works on a different host port" || { echo "  FAIL  broken on a different host port ($alt)"; fail=1; }
 
@@ -202,13 +206,10 @@ if [ "$fail" = 0 ]; then
 	docker rm -f "$NAME-copy" >/dev/null 2>&1
 	# shellcheck disable=SC2086
 	docker run -d --name "$NAME-copy" $PLATFORM_ARG $EXTRA -p "$COPY_PORT":3000 -v "$COPY":/data "$IMAGE" >/dev/null 2>&1
-	# Break on any answer at all and let the case below judge it. Breaking only
-	# on a redirect meant the success path, which serves / directly, never
-	# matched and every green run waited out the full loop.
-	for _ in $(seq 1 20); do
-		sleep 2
-		[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$COPY_PORT/healthz" 2>/dev/null)" = "200" ] && break
-	done
+	# Waiting on /healthz rather than on a redirect: the success path serves /
+	# directly, so a loop that broke on a redirect never matched and every green
+	# run waited out the full timeout.
+	wait_for_healthz "$COPY_PORT" >/dev/null
 	cp_url=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 10 "http://localhost:$COPY_PORT/" 2>/dev/null)
 	case "$cp_url" in
 		*/setup) echo "  FAIL  a copied data directory comes up unconfigured"; fail=1 ;;

--- a/packaging/umbrel/docker-compose.yml
+++ b/packaging/umbrel/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: popcorn-vote_main_1
+      APP_PORT: 3000
+      # Umbrel auth is off for this app on purpose, and the reasoning is the
+      # opposite of the usual one: it is not that the app's own login would
+      # break, it is who the app is for. Popcorn Vote is used by the whole
+      # family from their own phones and tablets, while the Umbrel login belongs
+      # to whoever runs the server. Leaving Umbrel auth in front would mean
+      # handing the server password to the children in order to let them vote on
+      # a film, which is a far worse trade than the four-digit family PIN the
+      # app asks for and rate-limits per address.
+      PROXY_AUTH_ADD: "false"
+
+  main:
+    image: ghcr.io/stadicus/popcorn-vote:1.2.0@sha256:03e8f36ca31419f656a1d4286d851945b0c890c97b9aa5b4b32fcd66f35295b6
+    # The image already runs as node, which is uid/gid 1000, matching the
+    # ownership Umbrel gives app data. Stated explicitly so a future base-image
+    # change cannot silently move it and leave the data directory unwritable.
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      # Everything worth keeping: the SQLite database, downloaded posters and
+      # the nightly backups. Nothing else in the container survives an update.
+      - ${APP_DATA_DIR}/data:/data

--- a/packaging/umbrel/umbrel-app.yml
+++ b/packaging/umbrel/umbrel-app.yml
@@ -1,0 +1,57 @@
+manifestVersion: 1
+id: popcorn-vote
+category: media
+name: Popcorn Vote
+version: "1.2.0"
+tagline: Settle movie night fairly, with a vote instead of an argument
+description: >-
+  No more arguing about who gets to pick the film. Everyone suggests films,
+  everyone gets one vote a week, and votes can be saved up — so the film only
+  one person is longing for eventually gets its turn too.
+
+
+  Before movie night somebody presses Evaluate: the most votes win, a wheel of
+  fortune settles a tie, and the winner is announced with a burst of popcorn.
+  Watched films go into the archive with star ratings, a shared family film
+  diary.
+
+
+  Everything is set up in the browser on first start: the family PIN, who is in
+  the family, the film database keys and the languages. Nothing to edit, no
+  console needed.
+
+
+  - Mobile-first and installable as an app on Android and iOS
+
+
+  - One four-digit PIN for the whole family, with a brute-force brake, rather
+    than an account per person
+
+
+  - Posters, descriptions, runtimes, genres, IMDb ratings and trailers from TMDB
+    and OMDb; both are free for private use and each needs its own key, which
+    the setup asks for
+
+
+  - Nine interface languages: English, German, Spanish, French, Brazilian
+    Portuguese, Italian, Polish, Turkish and Japanese
+
+
+  This app is reached without an Umbrel login on purpose, so that everyone in
+  the family can use it from their own phone without the password to your
+  server. The four-digit PIN it asks for is a house key, not a safe: whoever
+  knows it can also spend other people's votes. Inside one family that is the
+  point.
+releaseNotes: ""
+developer: Stadicus
+website: https://popcornvote.org
+dependencies: []
+repo: https://github.com/Stadicus/popcorn-vote
+support: https://github.com/Stadicus/popcorn-vote/issues
+port: 3019
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Stadicus
+submission: ""

--- a/packaging/umbrel/umbrel-app.yml
+++ b/packaging/umbrel/umbrel-app.yml
@@ -54,4 +54,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: Stadicus
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5994


### PR DESCRIPTION
Adds `packaging/umbrel/` as the source the store pull request is fed from, and
records the submission: https://github.com/getumbrel/umbrel-apps/pull/5994
(draft). The two files here are byte-identical to the submitted ones.

Umbrel's own linter reports `No issues found` including `--check-images`.

### Two deliberate choices that read like oversights

`PROXY_AUTH_ADD: "false"` turns the Umbrel login off for this app. Not because
the app's own login would break behind the proxy, but because of who the app is
for: the family votes from their own phones, while the Umbrel password belongs
to whoever runs the server. Leaving that login in front would mean handing the
server password to the children.

The host port is 3019 rather than 3009. The catalogue's manifests leave 3009
free, but samourai-server's `nginx` compose service publishes it, so the port
has to be checked against manifests *and* compose files. The store's linter
confirms both readings.

### What `check.sh` grew

Each new check was confirmed to fail when the fact it guards is broken, not
merely to pass today: APP_PORT and data path against `docker-compose.yml`, data
under `${APP_DATA_DIR}`, APP_HOST against the app id, a pinned digest whose tag
and manifest version match `package.json`, YAML well-formedness, and that the
data directory is tracked by git at all.

That last one is not theoretical. The root `.gitignore` has a `data/` rule that
silently swallowed `packaging/umbrel/data/`, and git never descends into an
ignored directory, so the package looked complete locally and would have arrived
at the store one directory short. `.gitignore` now carves it out.

### A defect in the test itself

`test-install.sh` probed `/healthz` immediately after the container reported
`Up`, while every later phase polled for it. On amd64 the server binds fast
enough to hide that; the first arm64 pass reported a broken package for a
perfectly good image. One helper now waits in all five places.

### Verification

Against the published `1.2.0` digest, all eleven checks pass:

- Umbrel ownership (`1000:1000`) on amd64
- Umbrel ownership (`1000:1000`) on arm64 under emulation
- Unraid ownership (`99:100`) on amd64

Removing `--user` still reproduces the `EACCES` failure the test exists for, so
the suite has not been quietly defanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)