### PR TITLE
Prepare v1.3 app-store runtime and packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ data
 .git
 .github
 .claude
+family-movie-night
 .gitignore
 .env
 .env.*

--- a/.github/no-german-characters.sh
+++ b/.github/no-german-characters.sh
@@ -20,6 +20,7 @@ svelte.config.js vite.config.ts playwright.config.ts eslint.config.js tsconfig.j
 README.md CHANGELOG.md SPECIFICATION.md DOCUMENTATION.md SECURITY.md CONTRIBUTING.md
 CODE_OF_CONDUCT.md
 config.example.yaml .env.example docker-compose.yml Dockerfile render.yaml
+docker-entrypoint.sh packaging .trivyignore.yaml
 )
 
 # Every root has to exist, or a rename would quietly shrink what is scanned and
@@ -99,6 +100,10 @@ allow=(
 	# Generated locale pages and the x-default gateway repeat native language
 	# names and localized copy. Hand-maintained website documentation stays scanned.
 	'^docs/website/(index\.html|(?:en|de|es|fr|pt-br|it|pl|tr|ja)/index\.html):'
+	# Store-facing translation catalogues and CasaOS's required inline de_DE
+	# fields are reviewed localized UI copy, not implementation prose.
+	'^packaging/home-assistant/translations/de\.yaml:'
+	'^packaging/casaos/docker-compose\.template\.yml:'
 	# This script has to name the characters it looks for.
 	'^\.github/no-german-characters\.sh:'
 	# Native language names are shown in the language switcher.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          # The packaging publication gate compares recognized package files
-          # with the pull-request base. A shallow checkout can make that diff
-          # silently empty, which would fail open.
-          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -31,6 +26,45 @@ jobs:
       # blocks unconditionally: a key that reaches a public repository is out of
       # our hands the moment it is pushed, whatever the rest of the run says.
       - run: npm run lint:secrets
+      - run: npm run lint
+      - run: npm run check
+      # Include every TypeScript source file, including files no unit test loads,
+      # and fail if the established coverage floor regresses.
+      - run: npm run test:coverage
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: unit-test-coverage
+          path: coverage/
+          retention-days: 7
+      - run: npm run build
+      # Deliberately not blocking. A newly published advisory in some dependency
+      # is not a reason to hold up a fix the family is waiting for, and there is
+      # rarely anything to do about it in the same hour. The step goes red so it
+      # is seen; the run stays green so it is not in the way. `--omit=dev` is the
+      # honest scope: the image is built with `npm prune --omit=dev`, so nothing
+      # else ever runs in the container.
+      - run: npm audit --omit=dev --audit-level=high
+        continue-on-error: true
+
+  packaging:
+    # Pull requests get a unique check name that a ruleset can require without
+    # accepting the same commit's skip-allowed branch-push validation instead.
+    name: ${{ github.event_name == 'pull_request' && 'Packaging publication gate' || 'Packaging branch validation' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The publication gate compares recognized package files with the
+          # pull-request base. A shallow checkout can make that diff fail open.
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
       - name: Decide whether registry validation may skip
         id: packaging-registry
         shell: bash
@@ -52,26 +86,6 @@ jobs:
       - run: bash packaging/check.sh
         env:
           PACKAGING_REGISTRY_REQUIRED: ${{ steps.packaging-registry.outputs.required == 'true' && '1' || '0' }}
-      - run: npm run lint
-      - run: npm run check
-      # Include every TypeScript source file, including files no unit test loads,
-      # and fail if the established coverage floor regresses.
-      - run: npm run test:coverage
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: always()
-        with:
-          name: unit-test-coverage
-          path: coverage/
-          retention-days: 7
-      - run: npm run build
-      # Deliberately not blocking. A newly published advisory in some dependency
-      # is not a reason to hold up a fix the family is waiting for, and there is
-      # rarely anything to do about it in the same hour. The step goes red so it
-      # is seen; the run stays green so it is not in the way. `--omit=dev` is the
-      # honest scope: the image is built with `npm prune --omit=dev`, so nothing
-      # else ever runs in the container.
-      - run: npm audit --omit=dev --audit-level=high
-        continue-on-error: true
 
   e2e:
     name: End-to-end (${{ matrix.browser }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The packaging publication gate compares recognized package files
+          # with the pull-request base. A shallow checkout can make that diff
+          # silently empty, which would fail open.
+          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -26,6 +31,25 @@ jobs:
       # blocks unconditionally: a key that reaches a public repository is out of
       # our hands the moment it is pushed, whatever the rest of the run says.
       - run: npm run lint:secrets
+      - name: Decide whether registry validation may skip
+        id: packaging-registry
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          required=false
+          if [ "$EVENT_NAME" = pull_request ]; then
+            required=$(bash packaging/registry-required.sh "$BASE_SHA" HEAD)
+          fi
+          # Push runs deliberately use ordinary skip-allowed mode. Publication
+          # references are proven in their pull request; a transient registry
+          # outage must not make the post-merge CI run unrepeatably block a release.
+          echo "required=$required" >> "$GITHUB_OUTPUT"
+      - run: bash packaging/check.sh
+        env:
+          PACKAGING_REGISTRY_REQUIRED: ${{ steps.packaging-registry.outputs.required == 'true' && '1' || '0' }}
       - run: npm run lint
       - run: npm run check
       # Include every TypeScript source file, including files no unit test loads,
@@ -93,16 +117,45 @@ jobs:
           retention-days: 7
 
   docker:
-    name: Docker image builds
-    runs-on: ubuntu-latest
+    name: Docker image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            hass_arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            hass_arch: aarch64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          build-args: GITHUB_SHA=${{ github.sha }}
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            BUILD_VERSION=ci
+            BUILD_ARCH=${{ matrix.hass_arch }}
+          platforms: ${{ matrix.platform }}
+          load: true
           push: false
           tags: popcorn-vote:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ci-${{ matrix.hass_arch }}
+          cache-to: type=gha,mode=max,scope=ci-${{ matrix.hass_arch }}
+      - name: Check Home Assistant labels
+        shell: bash
+        env:
+          EXPECTED_ARCH: ${{ matrix.hass_arch }}
+        run: |
+          set -euo pipefail
+          test "$(docker image inspect popcorn-vote:ci --format '{{index .Config.Labels "io.hass.version"}}')" = ci
+          test "$(docker image inspect popcorn-vote:ci --format '{{index .Config.Labels "io.hass.type"}}')" = app
+          test "$(docker image inspect popcorn-vote:ci --format '{{index .Config.Labels "io.hass.arch"}}')" = "$EXPECTED_ARCH"
+      - run: IMAGE=popcorn-vote:ci bash packaging/test-root-owned-install.sh
+      - name: Test Unraid install contract
+        run: IMAGE=popcorn-vote:ci bash packaging/test-install.sh
+      - name: Test Umbrel install contract
+        run: IMAGE=popcorn-vote:ci UIDGID=1000:1000 EXTRA='--user 1000:1000' bash packaging/test-install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           # references are proven in their pull request; a transient registry
           # outage must not make the post-merge CI run unrepeatably block a release.
           echo "required=$required" >> "$GITHUB_OUTPUT"
+      - run: bash packaging/test-registry-required.sh
+      - run: bash packaging/test-yaml-discovery.sh
       - run: bash packaging/check.sh
         env:
           PACKAGING_REGISTRY_REQUIRED: ${{ steps.packaging-registry.outputs.required == 'true' && '1' || '0' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,8 +186,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
+            hass_arch: amd64
             runner: ubuntu-latest
           - platform: linux/arm64
+            hass_arch: aarch64
             runner: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -214,7 +216,10 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          build-args: GITHUB_SHA=${{ needs.gate.outputs.release_sha }}
+          build-args: |
+            GITHUB_SHA=${{ needs.gate.outputs.release_sha }}
+            BUILD_VERSION=${{ needs.notes.outputs.version }}
+            BUILD_ARCH=${{ matrix.hass_arch }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ steps.target.outputs.image }},push-by-digest=true,name-canonical=true,push=true
           # Provenance and bill of materials: they answer, for outsiders, which

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           # A manual click chooses when to publish, but it cannot bypass the
           # quality gates for the exact commit being released.
           deadline=$((SECONDS + 1800))
-          for workflow in ci.yml security.yml; do
+          for workflow in ci.yml security.yml codeql.yml; do
             while true; do
               line=$(
                 gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs?event=push&branch=main&head_sha=$release_sha&per_page=1" \
@@ -261,6 +261,7 @@ jobs:
       packages: write
     outputs:
       published: ${{ steps.publish.outputs.published }}
+      manifest_digest: ${{ steps.inspect.outputs.manifest_digest }}
     steps:
       # No checkout: since the build sits next door, no step here touches a file
       # from the tree any more.
@@ -362,20 +363,102 @@ jobs:
 
           docker buildx imagetools create "${tags[@]}" "${digest_refs[@]}"
           echo "published=true" >> "$GITHUB_OUTPUT"
-      - name: Inspect the result
+      - name: Inspect the result and record release metadata
+        id: inspect
         if: steps.publish.outputs.published == 'true'
+        # Publication above is the point of no return for the immutable version
+        # tag. A transient registry read or summary-write failure must not
+        # suppress the matching GitHub release and strand that tag. Retries
+        # still make this useful as the normal post-publication verification.
+        continue-on-error: true
         shell: bash
         env:
           IMAGE: ${{ steps.target.outputs.image }}
+          RELEASE_SHA: ${{ needs.gate.outputs.release_sha }}
           VERSION: ${{ needs.notes.outputs.version }}
           VERSION_NEW: ${{ needs.notes.outputs.version_new }}
         run: |
           set -euo pipefail
           if [ "$VERSION_NEW" = true ]; then
-            docker buildx imagetools inspect "$IMAGE:$VERSION"
+            reference="$IMAGE:$VERSION"
           else
-            docker buildx imagetools inspect "$IMAGE:latest"
+            reference="$IMAGE:latest"
           fi
+
+          inspection=
+          for attempt in 1 2 3 4 5; do
+            if inspection=$(docker buildx imagetools inspect "$reference"); then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::Could not inspect $reference after $attempt attempts."
+              exit 1
+            fi
+            sleep 5
+          done
+          printf '%s\n' "$inspection"
+          digest=$(awk "/^Digest:[[:space:]]+sha256:/{print \$2; exit}" <<< "$inspection")
+          if [[ ! $digest =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Could not read the manifest-list digest from $reference."
+            exit 1
+          fi
+
+          echo "manifest_digest=$digest" >> "$GITHUB_OUTPUT"
+          {
+            echo '## Published container manifest'
+            echo
+            echo "- Tag: \`$reference\`"
+            echo "- Manifest digest: \`$digest\`"
+            echo "- Immutable reference: \`$IMAGE@$digest\`"
+            echo "- Source commit: \`$RELEASE_SHA\`"
+            echo
+            echo "A following best-effort step stores the same digest in the \`release-metadata\` workflow artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Create machine-readable release metadata
+        id: metadata
+        if: steps.publish.outputs.published == 'true' && steps.inspect.outcome == 'success'
+        # Convenience output only: a JSON-generation failure after publication
+        # must not orphan the tag.
+        continue-on-error: true
+        shell: bash
+        env:
+          DIGEST: ${{ steps.inspect.outputs.manifest_digest }}
+          IMAGE: ${{ steps.target.outputs.image }}
+          RELEASE_SHA: ${{ needs.gate.outputs.release_sha }}
+          VERSION: ${{ needs.notes.outputs.version }}
+          VERSION_NEW: ${{ needs.notes.outputs.version_new }}
+        run: |
+          set -euo pipefail
+          if [ "$VERSION_NEW" = true ]; then
+            reference="$IMAGE:$VERSION"
+          else
+            reference="$IMAGE:latest"
+          fi
+          metadata="$RUNNER_TEMP/release-metadata.json"
+          metadata_filter="{version: \$version, version_new: \$version_new, image: \$image, tag: \$tag, digest: \$digest, immutable_reference: \$immutable_reference, release_sha: \$release_sha}"
+          jq -n \
+            --arg version "$VERSION" \
+            --argjson version_new "$VERSION_NEW" \
+            --arg image "$IMAGE" \
+            --arg tag "$reference" \
+            --arg digest "$DIGEST" \
+            --arg immutable_reference "$IMAGE@$DIGEST" \
+            --arg release_sha "$RELEASE_SHA" \
+            "$metadata_filter" \
+            > "$metadata"
+          echo "metadata_path=$metadata" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: steps.publish.outputs.published == 'true' && steps.metadata.outcome == 'success'
+        # The immutable image tag already exists at this point. A transient
+        # artifact-service failure must not suppress the matching GitHub release
+        # and leave an orphan tag that the next run correctly refuses to move.
+        continue-on-error: true
+        with:
+          name: release-metadata-${{ needs.notes.outputs.version }}
+          path: ${{ steps.metadata.outputs.metadata_path }}
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
 
   release:
     name: Publish tag and release

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           scan-type: fs
           scan-ref: .
+          trivyignores: .trivyignore.yaml
           scanners: vuln,secret,misconfig
           severity: HIGH,CRITICAL
           exit-code: '1'
@@ -67,6 +68,7 @@ jobs:
       - uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: popcorn-vote:security
+          trivyignores: .trivyignore.yaml
           scanners: vuln,secret,misconfig
           severity: HIGH,CRITICAL
           exit-code: '1'

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,9 @@ docs/website/
 .claude/
 CLAUDE-SECURITY-*/
 
+# Unrelated local project explicitly kept outside this repository.
+family-movie-night/
+
 # The store owns the style here, not this repository. Prettier would rewrite the
 # double quotes the whole Umbrel catalogue uses into single ones, and these two
 # files have to stay byte-identical to the ones in the submission pull request.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,7 @@
+misconfigurations:
+  - id: AVD-DS-0002
+    statement: >-
+      The image starts as root only to adopt the app-store-owned /data mount.
+      Its fail-closed entrypoint then execs the application as uid 1000; CI
+      verifies the uid on every supported architecture. An explicit Docker
+      --user bypasses all root-time work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Strengthened package discovery, version-lag, image pinning, architecture,
   privilege, and registry gates. Store metadata may intentionally remain one
   release behind the application, but it cannot point at an unavailable image.
+- Gave the strict pull-request publication check an unambiguous status name,
+  added CodeQL to the exact-commit release gate, and made each successful image
+  publication report its manifest digest in a best-effort summary and JSON
+  artifact.
 
 ## v1.2.0 Reliable health, a safer default, and the first app store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v1.3.0 App-store runtime and release preparation
+
+- Made the production image adopt a root-owned `/data` mount once and then
+  replace itself with the unprivileged `node` process. This enables managed
+  app-store storage without changing the existing explicit `--user` path used
+  by Unraid and Umbrel.
+- Added the Home Assistant image labels to both native release architectures and
+  CI checks that verify the labels, non-root application process, first-run
+  setup, restart, update, port change, backup restore, and both supported data
+  ownership paths.
+- Prepared non-discoverable Home Assistant and CasaOS package templates plus a
+  fail-closed materializer that accepts only a pullable multi-architecture image
+  with matching Home Assistant labels. After this release, one reviewed metadata
+  update can publish both packages and move Umbrel to the same manifest digest.
+- Strengthened package discovery, version-lag, image pinning, architecture,
+  privilege, and registry gates. Store metadata may intentionally remain one
+  release behind the application, but it cannot point at an unavailable image.
+
 ## v1.2.0 Reliable health, a safer default, and the first app store
 
 - Fixed the container health check, which reported every installation as

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -644,9 +644,10 @@ pre-built image, then start a container with:
   examples here. On a machine with a public address, bind that port to
   `127.0.0.1`, or it stands open on the internet as plain HTTP past the proxy
 - **Volume:** a folder or Docker volume, mounted as `/data` – this is
-  where the database, posters, backups, and `config.yaml` live. For a host
-  folder, make it writable for UID/GID `1000`; named Docker volumes get the
-  right ownership from the image when they are created.
+  where the database, posters, backups, and `config.yaml` live. On its first
+  start the container adopts a root-owned host folder, then runs the application
+  as UID/GID `1000`. An explicit Docker `--user` remains untouched and must
+  already match the folder ownership.
 - **Environment variables:** `TMDB_API_KEY` and `OMDB_API_KEY` for the movie
 	database keys. `PV_PIN` remains available only for installations migrating
 	from the former shared-PIN model.
@@ -726,29 +727,42 @@ once and, at the cap, pushes the oldest one out.
 start the container on the new device with the same volume. Nothing else
 is needed – everything is in that one folder.
 
-**Fixing `/data` permissions:** images run as the container user `node`
-(UID/GID `1000`). Named Docker volumes created from the image get that ownership
-automatically. For a bind-mounted folder with different ownership, stop the
-container and change it once:
+**Fixing `/data` permissions:** the container may start as root only long enough
+to adopt a new `/data` mount, then replaces itself with the application as
+`node` (UID/GID `1000`). The recursive ownership migration runs once and records
+that fact in `/data/.ownership-migrated`; later starts touch only the directory
+itself. Files owned by the Home Assistant Supervisor, such as `options.json`,
+are deliberately excluded.
+
+If data was copied or restored as root after that marker was created, stop the
+container, remove the marker and start it again. The next start repeats the
+bounded migration:
 
 ```sh
-sudo chown -R 1000:1000 /srv/popcorn-vote/data
+sudo rm /srv/popcorn-vote/data/.ownership-migrated
 ```
 
-For a named Docker volume, run the same ownership change through a temporary
-container, replacing the volume name if yours is different:
+For a named Docker volume, remove it through a temporary container, replacing
+the volume name if yours is different:
 
 ```sh
-docker run --rm -v popcorn-vote-data:/data alpine chown -R 1000:1000 /data
+docker run --rm -v popcorn-vote-data:/data alpine rm -f /data/.ownership-migrated
 ```
+
+An operator who sets Docker's `--user` bypasses this migration deliberately.
+In that case, make the folder writable by that UID/GID before starting the
+container.
 
 ---
 
 ## 9. When something goes wrong
 
 **"The first-run setup cannot save the administrator."**
-The container must be able to write `/data`. Check the mounted volume's
-permissions for UID/GID `1000`; the setup writes `/data/config.yaml` there.
+The container must be able to write `/data`; the setup writes
+`/data/config.yaml` there. Check the startup log for an unsafe `DATA_DIR` or a
+failed privilege drop. With an explicit Docker `--user`, check that the mounted
+folder belongs to that UID/GID. After externally restoring files as root, use
+the ownership-marker recovery above.
 
 **"Forgotten every administrator PIN."**
 This deliberately has no unauthenticated reset button. An operator with access

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ RUN npm run build && npm prune --omit=dev
 
 FROM node:22-alpine
 
+# Home Assistant app labels. Release builds pass both values explicitly for
+# each architecture before the images are joined into one manifest. Empty
+# defaults keep ordinary local Docker builds possible without pretending that a
+# development image is a released Home Assistant app.
+ARG BUILD_VERSION=""
+ARG BUILD_ARCH=""
+
 # On the final stage, or they would describe the build stage and never reach the
 # published image. `image.source` is the one that does more than describe: it is
 # what links the package on GHCR to its repository, so the package page carries
@@ -28,7 +35,10 @@ FROM node:22-alpine
 LABEL org.opencontainers.image.title="Popcorn Vote" \
       org.opencontainers.image.description="Self-hosted voting on film suggestions for family movie night." \
       org.opencontainers.image.source="https://github.com/Stadicus/popcorn-vote" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="MIT" \
+      io.hass.version="$BUILD_VERSION" \
+      io.hass.type="app" \
+      io.hass.arch="$BUILD_ARCH"
 
 WORKDIR /app
 ENV NODE_ENV=production \
@@ -37,11 +47,18 @@ ENV NODE_ENV=production \
 COPY --from=build /app/build ./build
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./
-RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx && \
+COPY docker-entrypoint.sh /usr/local/bin/popcorn-vote-entrypoint
+RUN apk add --no-cache su-exec && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx && \
+    chmod 0755 /usr/local/bin/popcorn-vote-entrypoint && \
     mkdir -p /data && chown node:node /data
 VOLUME /data
 EXPOSE 3000
-USER node
+# App stores create the persistent mount before the container starts, often as
+# root. The entrypoint adopts that mount once and immediately replaces itself
+# with the application as `node`. An explicit Docker --user remains respected:
+# that path never starts as root and performs no ownership changes.
+ENTRYPOINT ["popcorn-vote-entrypoint"]
 # 127.0.0.1 rather than localhost: the server binds 0.0.0.0, which is IPv4 only,
 # while `localhost` also resolves to ::1 in the container and busybox wget tries
 # that first. The check then answers "connection refused" for an application

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,7 @@ if [ ! -e "$sentinel" ]; then
 	# to the Home Assistant Supervisor and the application deliberately ignores it.
 	find "$data_dir" -xdev \
 		-path "$data_dir/options.json" -prune -o \
-		-exec chown -h node:node {} \;
+		-exec chown -h node:node {} +
 	: > "$sentinel"
 	chown node:node "$sentinel"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Make an app-store-owned data mount usable, then permanently drop privileges.
+# No application code or user-supplied command is ever run as root.
+set -eu
+
+if [ "$(id -u)" -ne 0 ]; then
+	exec "$@"
+fi
+
+if ! command -v su-exec >/dev/null 2>&1; then
+	echo "Cannot drop privileges: su-exec is not installed." >&2
+	exit 1
+fi
+
+data_dir=${DATA_DIR:-/data}
+sentinel="$data_dir/.ownership-migrated"
+
+case "$data_dir" in
+	"" | /)
+		echo "Refusing to manage an unsafe DATA_DIR: '${data_dir:-<empty>}'" >&2
+		exit 1
+		;;
+	/*) ;;
+	*)
+		echo "DATA_DIR must be an absolute path: $data_dir" >&2
+		exit 1
+		;;
+esac
+
+if [ -L "$data_dir" ]; then
+	echo "Refusing to manage a DATA_DIR that is a symbolic link: $data_dir" >&2
+	exit 1
+fi
+
+if [ -L "$sentinel" ]; then
+	echo "Refusing to use a symbolic-link ownership marker: $sentinel" >&2
+	exit 1
+fi
+
+mkdir -p "$data_dir"
+chown node:node "$data_dir"
+
+if [ ! -e "$sentinel" ]; then
+	# find does not follow symlinks by default; -xdev also prevents a nested
+	# mount from widening this one-time ownership migration. options.json belongs
+	# to the Home Assistant Supervisor and the application deliberately ignores it.
+	find "$data_dir" -xdev \
+		-path "$data_dir/options.json" -prune -o \
+		-exec chown -h node:node {} \;
+	: > "$sentinel"
+	chown node:node "$sentinel"
+fi
+
+exec su-exec node:node "$@"

--- a/docs/distribution-packaging-plan.md
+++ b/docs/distribution-packaging-plan.md
@@ -960,8 +960,10 @@ Assistant OS installation:
 8. Change the host port in Home Assistant and verify the Web UI link and direct
    access.
 9. Create and restore a Home Assistant backup containing the app.
-10. Inspect logs for permission, health, architecture, and shutdown errors.
-11. Verify that no Home Assistant or Supervisor token is available to the app
+10. Confirm the installed app configuration has `init: false` and the app
+    container's PID 1 is the Node.js process running as uid 1000, not root.
+11. Inspect logs for permission, health, architecture, and shutdown errors.
+12. Verify that no Home Assistant or Supervisor token is available to the app
     unless the platform injects one independently of requested permissions.
 
 Device testing on both architecture families is not realistic for the first

--- a/docs/distribution-packaging-plan.md
+++ b/docs/distribution-packaging-plan.md
@@ -625,6 +625,11 @@ first release bootstraps in two repository merges around one publication:
    architectures with the new labels and
    combines them with `imagetools create` into the multi-architecture manifest,
    publishing `ghcr.io/stadicus/popcorn-vote:1.3.0` and refreshing `:latest`.
+   The workflow makes a retried, best-effort inspection of the resulting
+   manifest-list digest, recording it in the job summary and a machine-readable
+   `release-metadata-1.3.0` artifact for step 3. Registry-read, summary, or
+   artifact-service failures cannot veto the GitHub release after the immutable
+   image tag exists.
 3. **Metadata merge.** Only now merge the store metadata, pinned to the verified
    `1.3.0` tag and — for Umbrel — its manifest-list digest. Discovery and
    advertisement begin at this merge, at which point the referenced image is
@@ -652,8 +657,9 @@ Consequences that implementation must respect:
   checks in a required, non-skipping mode, so a registry outage turns the pull
   request red instead of waving it through. Whether red actually *blocks* the
   merge depends on the required-status-check configuration described in Phase 5
-  — `main` is unprotected today, so until that is configured the block is the
-  operator declining to merge red, not the platform refusing it. The trigger is mechanical, not a label —
+  — the active ruleset does not yet require that check, so until it is added the
+  block is the operator declining to merge red, not the platform refusing it.
+  The trigger is mechanical, not a label —
   it is any pull request that adds or changes the effective image reference of a
   recognized package file (Phase 5), which covers the step-3 bootstrap merge and
   every routine version bump after it alike.
@@ -734,18 +740,21 @@ invariants so failures identify the actual contract that drifted.
 this implementation: add it as a job or step in `.github/workflows/ci.yml` so it
 runs on every pull request, resolving the open question left in PR #18.
 
-**A red check must actually block.** `main` currently has neither branch
-protection nor a repository ruleset (verified against the GitHub API), so today
-a failing `ci.yml` job stops nothing — anyone can merge a red pull request. That
-matters here more than for an ordinary lint failure: the fail-closed registry
-gate below is the only thing standing between a registry outage and store
-metadata advertising an image nobody proved exists, and this plan's own standard
-for that gate is mechanical enforcement, not a remembered convention.
+**A red check must actually block.** `main` has an active repository ruleset
+requiring pull requests and preventing deletion and non-fast-forward updates,
+but it does not yet require a status check. A failing `ci.yml` job therefore
+still stops nothing by itself. That matters here more than for an ordinary lint
+failure: the fail-closed registry gate below is the only thing standing between
+a registry outage and store metadata advertising an image nobody proved exists,
+and this plan's own standard for that gate is mechanical enforcement, not a
+remembered convention.
 
-Wiring `check.sh` into CI therefore includes making its job a **required status
-check on `main`**, via branch protection or a ruleset. Configuring repository
-protection is an operator action and falls under Autonomous Execution
-Boundaries: propose it, do not apply it unasked.
+Wiring `check.sh` into CI therefore includes a uniquely named
+**`Packaging publication gate`** job for pull requests. Its skip-allowed push
+counterpart is named `Packaging branch validation`, so a ruleset cannot confuse
+the two event modes. Make `Packaging publication gate` a required status check
+on `main`. Configuring that ruleset entry is an operator action and falls under
+Autonomous Execution Boundaries: propose it, do not apply it unasked.
 
 Until that protection exists, the honest statement of the guarantee is weaker
 and the plan says so rather than overclaiming: a failed registry check **fails

--- a/docs/distribution-packaging-plan.md
+++ b/docs/distribution-packaging-plan.md
@@ -1,0 +1,1050 @@
+# Distribution Packaging Plan
+
+## Status
+
+Reviewed implementation plan, now in execution. Home Assistant is the first
+remaining delivery target; Unraid and Umbrel are already present, while CasaOS
+follows on the same container contract.
+
+### Execution update — 2026-08-15
+
+The repository advanced after this plan was approved: release `v1.2.0` merged as
+PR #22, then the Umbrel package merged as PR #23 and was submitted upstream as
+`getumbrel/umbrel-apps#5994`. Both are now baseline, not work for this branch.
+They landed before the runtime merge prescribed below, so `v1.2.0` must not be
+retroactively advertised as the Home Assistant-compatible image. The next
+release containing the entrypoint and `io.hass.*` labels becomes the first image
+eligible for Home Assistant and CasaOS metadata. Umbrel 1.2.0 remains compatible
+through its explicit `user: "1000:1000"`; its next metadata bump follows that
+new release in the usual publish-then-metadata order.
+
+The three-step bootstrap sequence below remains the design record for why image
+publication must precede versioned store metadata. Its `v1.2.0` references
+describe the originally approved sequence; this execution update supersedes
+them where the live repository has already moved on.
+
+### Existing baseline (not net-new work)
+
+**The Unraid packaging is already merged to `main`.** Pull request
+[#18](https://github.com/Stadicus/popcorn-vote/pull/18) ("Unraid Community
+Applications Template") was squash-merged as commit `0bf3f08` on
+2026-08-15. Two further pull requests merged alongside it — #19
+(`ADDRESS_HEADER` safe default and startup notice) and #20 (container health
+check fix) — both consistent with the rules below. There is no open branch left
+to amend: everything below is a correction to `main`, delivered as ordinary
+follow-up pull requests.
+
+**The baseline is `main`'s current state, deliberately not a fixed commit.** The
+packaging work moved five times during this plan's review (`41f406e` →
+`17b87d7` → `b3ccd8c` → `4c0f87a` → `b29cc0f`, then merged as `0bf3f08`).
+Pinning a SHA here produced a stale, wrong plan three review rounds running. The
+rule instead:
+
+- Implementation reads `main` at the moment it starts and builds on it.
+- Everything this plan prescribes is stated against the **role** of each file,
+  not a snapshot of its content. Where a correction names current content,
+  verify it still applies before changing it.
+- Nothing already on `main` may be dropped by a correction. When a correction
+  and a newer commit collide, the newer commit wins on facts about the platform,
+  this plan wins on the packaging contract — and the collision is worth a note
+  in the pull request that resolves it.
+
+These files are on `main` today, by role:
+
+| File | Role | This plan's disposition |
+| --- | --- | --- |
+| `packaging/README.md` | Store-package overview | Extend (Phase 2, Phase 3) |
+| `packaging/check.sh` | Metadata validation | Extend in place (Phase 5) |
+| `packaging/test-install.sh` | Store-install test against a real container | Keep, extend only on contract change (Phase 5) |
+| `packaging/unraid/popcorn-vote.xml` | Unraid CA template | Correct in place (Phase 3), keep `ExtraParams` |
+| `packaging/unraid/ca_profile.xml` | Maintainer profile | Keep; the CA submission scan found and parsed it in place |
+
+**Unraid is already shipped.** The repository was submitted through the
+Community Applications portal on 2026-08-15 and auto-approved. The scan found
+the nested template and extracted the maintainer profile from
+`packaging/unraid/ca_profile.xml`; these two discovery questions are therefore
+closed by observed platform behavior. The template deliberately follows
+`:latest` and starts as `99:100`, so it does not depend on the root-owned-mount
+migration introduced for the other stores. The scan result and delivery path
+are recorded in `packaging/README.md`, "How the Unraid package reaches users".
+
+Two things on `main` are load-bearing for this plan and must survive every
+correction it prescribes:
+
+- **The Unraid uid fix.** Unraid creates appdata directories as `nobody:users`
+  (99:100) while the image runs as `node`, so without
+  `<ExtraParams>--user 99:100</ExtraParams>` the container cannot write `/data`
+  and crash-loops on `EACCES /data/covers`. See "Container user on Unraid" in
+  Phase 3.
+- **`packaging/test-install.sh`.** It has grown past the original ownership check
+  and now exercises the full store-install journey against a real container —
+  health polling, first-run setup through the API, restart and update
+  persistence, host-port change, and backup/restore. Treat its current coverage
+  as the reference when reading Phase 5, and read the file rather than this
+  description before changing it.
+
+Implementation builds on `main`. Those files are an existing baseline to be
+reviewed against this plan and corrected in place — not recreated and not
+superseded by a parallel implementation. Where this plan and the merged files
+disagree on the packaging contract, this plan wins; where they disagree on a
+platform fact, the merged file wins unless this plan cites a source (see the
+collision rule above). The two rules already codified in `packaging/README.md`
+(no `ADDRESS_HEADER` in package defaults, nothing required from the user before
+the first-run wizard) are part of the Shared Container Contract below. Every
+other file named in this document is still net-new.
+
+PR #18 left two discovery questions open; the later submission scan resolved
+both successfully without moving either file. Wiring `packaging/check.sh` into
+CI remains part of Phase 5.
+
+## Objective
+
+Make Popcorn Vote installable through common home-server application stores
+without creating platform-specific application forks or independent runtime
+images. Every package must run the published multi-architecture image and keep
+the existing browser-based first-run setup.
+
+The first Home Assistant release must be reachable directly on the local network
+at `http://homeassistant.local:3000` (or the host IP and selected port). It must
+not depend on Home Assistant Ingress, Home Assistant authentication, or access to
+the Home Assistant or Supervisor APIs.
+
+## Scope
+
+### Included
+
+- A common packaging layout for Home Assistant, Unraid, Umbrel, and CasaOS.
+- Home Assistant repository metadata and a complete first installable app.
+- Container startup changes needed for a Supervisor-owned `/data` mount.
+- Store metadata for Unraid, Umbrel, and CasaOS.
+- Documentation for installation, updates, backups, network access, and
+  platform submission.
+- Automated checks that keep package metadata aligned with the application.
+- Multi-architecture publication for `linux/amd64` and `linux/arm64`.
+
+### Excluded from the first delivery
+
+- Home Assistant Ingress and sidebar embedding.
+- Home Assistant authentication or API integration.
+- Automatic router configuration or public port forwarding.
+- TLS termination inside the Popcorn Vote container.
+- A second platform-specific Popcorn Vote image.
+- Automatic submission to third-party stores.
+
+Ingress remains separate because the application currently uses root-relative
+API and asset URLs and ships a service worker. Supporting the dynamic
+`X-Ingress-Path` requires an application-level design and browser testing beyond
+packaging work.
+
+## Repository Layout
+
+```text
+repository.yaml
+
+packaging/
+  README.md            # on main — extend
+  check.sh             # on main — extend in place
+  test-install.sh      # on main — keep, extend only on contract change
+  home-assistant/
+    config.yaml
+    README.md
+    DOCS.md
+    CHANGELOG.md
+    icon.png
+    logo.png
+    translations/
+      de.yaml
+      en.yaml
+  unraid/
+    popcorn-vote.xml   # on main — correct in place, keep ExtraParams
+    ca_profile.xml     # on main — location and schema accepted by the CA scan
+  umbrel/
+    umbrel-app.yml
+    docker-compose.yml
+  casaos/
+    docker-compose.yml
+```
+
+One file is an intentional exception to the packaging directory because the
+consuming platform requires it at the root of the Git repository:
+
+- `repository.yaml` — Home Assistant requires it at the root of the repository
+  added to the app store. Recursive discovery of the app below it is confirmed
+  in Phase 2, "Platform facts (verified)".
+No package files should be placed in the existing untracked
+`family-movie-night/` directory, and implementation must not modify or add that
+directory to version control.
+
+## Shared Container Contract
+
+Every package must use the following values unless a platform forces a naming
+translation:
+
+| Property | Value |
+| --- | --- |
+| Image | `ghcr.io/stadicus/popcorn-vote` |
+| Immutable release tag | Version from `package.json` |
+| Moving convenience tag | `latest` — referenced only by the Unraid template (documented exception, Phase 3) |
+| Image reference form | Home Assistant and CasaOS: `ghcr.io/stadicus/popcorn-vote:<version>`; Umbrel additionally pins `@sha256:<manifest-list digest>`; Unraid: `:latest` |
+| Container port | `3000/tcp` |
+| Persistent path | `/data` |
+| Health endpoint | `/healthz` |
+| Architectures | `linux/amd64`, `linux/arm64` |
+| Default access | Local network only |
+| First-run configuration | Popcorn Vote browser wizard |
+
+The packaged defaults must not set `ADDRESS_HEADER`, `XFF_DEPTH`,
+`PROTOCOL_HEADER`, or `ORIGIN` when the application is exposed directly on a
+trusted local network. Platform documentation may explain how to set the proxy
+variables when a user deliberately puts a trusted reverse proxy in front of the
+application.
+
+TMDB and optional OMDb keys remain part of the Popcorn Vote first-run wizard.
+They must not be duplicated as mandatory store options.
+
+## Phase 1: Container Runtime Compatibility
+
+1. Add a small POSIX-compatible container entrypoint.
+2. When started as root, ensure that `DATA_DIR` exists and that the application
+   user can read and write it.
+3. Drop privileges to the existing `node` user before starting Node.js.
+4. When the operator explicitly starts the container as a non-root user, avoid
+   attempting privileged ownership changes and execute the application directly.
+5. Preserve the existing command, environment variables, exposed port, volume,
+   and health check behavior for Docker and Docker Compose users.
+6. Add only the minimal privilege-dropping dependency required by the final
+   Alpine image.
+
+The resulting Node.js process must not run as root. Startup must also work with
+a newly created root-owned bind mount, which approximates the directory supplied
+by the Home Assistant Supervisor.
+
+### Threat model
+
+This phase changes the image's default security posture and must document that
+change explicitly before implementation:
+
+a. **What changes.** The Dockerfile currently ends with `USER node`, so today the
+   container never starts as root for any consumer. Phase 1 removes that
+   directive: the container starts as root by default for every existing Docker
+   and Docker Compose user, and drops privileges inside the entrypoint.
+
+b. **What the entrypoint may do while root.** Exactly two operations: create
+   `DATA_DIR` if it is missing, and adjust its ownership so the `node` user can
+   read and write it. The ownership operation is specified precisely, because
+   the choice has both a correctness and a blast-radius consequence: a
+   non-recursive `chown` on a pre-existing, populated, root-owned directory
+   leaves its contents unwritable, while an unconditional recursive `chown`
+   traverses whatever the operator mounted and makes the root window
+   proportional to the mount size rather than constant. The entrypoint therefore
+   `chown`s `DATA_DIR` itself on every start, and runs a recursive pass **at most
+   once ever**, gated on a sentinel file — `${DATA_DIR}/.ownership-migrated` —
+   that it writes after the first successful pass, never before it. The trigger is the sentinel's absence, not an ownership
+   probe of the directory contents: on Home Assistant the Supervisor writes a
+   root-owned `/data/options.json` that coexists with Popcorn Vote data (see
+   Phase 2), so "contents not owned by `node`" is true in every normal install
+   and would re-trigger the recursive pass on every start. The recursive pass
+   must additionally **skip platform-owned files** — at minimum
+   `/data/options.json`, which the application is required to ignore anyway and
+   which the Supervisor rewrites at will. It must not follow symlinks out of
+   `DATA_DIR` when descending. Nothing else
+   runs as root — no package installation, no network access, no reading or
+   writing outside `DATA_DIR`, no execution of user-supplied content. The
+   entrypoint then `exec`s the application through the privilege-drop helper.
+
+c. **Blast radius and fail-closed rule.** The root window is the time between
+   container start and the `exec`: a few milliseconds on every start, plus a
+   single recursive pass on the very first start after the entrypoint is
+   introduced. The sentinel is what makes "once" enforceable rather than
+   aspirational — without it the pass would recur on every start on Home
+   Assistant. On Unraid the window does not exist at all, because the container
+   starts non-root (see Phase 3, "Container user on Unraid"). A compromise of the
+   entrypoint script or the privilege-drop helper in that window yields root
+   inside the container, which on the Home Assistant Supervisor and on default
+   Docker means root over the mounted `/data` and any capability the runtime
+   grants the container. The entrypoint must therefore fail closed: if the
+   privilege drop cannot be performed, it exits non-zero and the application does
+   not start. Falling through and running Node.js as root is forbidden. The
+   acceptance criterion "the application process does not run as root after
+   initialization" is verified in CI (Phase 5 smoke test step 5).
+
+d. **Why root-then-drop over the alternatives.** The constraint that forces it
+   is **Home Assistant specifically**: the Supervisor creates and owns the
+   `/data` mount, the package cannot choose the uid the container runs as, and
+   the user has no host shell to fix ownership. Three alternatives were
+   considered and rejected for that case: keeping `USER node` and documenting a
+   host-side `chown` (impossible — no host shell, Supervisor-owned mount); a
+   PUID/PGID convention (still requires a root window to change ownership, and
+   adds two user-facing options the Home Assistant package explicitly does not
+   want); and an init-container pattern (not expressible in a Home Assistant app
+   or an Unraid Community Applications template, both of which describe a single
+   container). Root-then-drop is the pattern the Home Assistant ecosystem itself
+   uses.
+
+   The criterion for skipping root-then-drop is narrower than "the package can
+   set a uid": it is **the platform supplies a uid convention the mount already
+   follows**. Unraid is the only case — it creates appdata as `nobody:users`, so
+   the template's `--user 99:100` matches an ownership that already exists, the
+   container starts non-root, and the entrypoint execs directly (see Phase 3,
+   "Container user on Unraid").
+
+   Umbrel and CasaOS technically permit a Compose `user:` directive, but neither
+   publishes a uid convention for the app-data directory it creates, so any value
+   the package picked would be arbitrary and would recreate exactly the
+   unwritable-mount problem this phase exists to solve. They therefore keep
+   root-then-drop, as does Home Assistant, which cannot set a uid at all. Phase 5
+   maps each platform to its path explicitly; this criterion and that mapping
+   must stay in agreement.
+
+e. **LAN exposure model, shared by all four stores.** The container serves plain
+   HTTP on the local network with no platform authentication in front of it, by
+   design (see Objective). Consequences that the package documentation must
+   state: any device on the LAN can reach the application; between installation
+   and completed first-run setup the setup wizard is unauthenticated, so whoever
+   reaches it first can claim the instance — users must complete setup
+   immediately after install and on a trusted network; traffic is unencrypted, so
+   the port must never be forwarded from the router, and remote access goes
+   through a VPN.
+
+## Phase 2: Home Assistant Package
+
+### Repository metadata
+
+Add root-level `repository.yaml` with the repository name, project URL, and
+maintainer information required by Home Assistant.
+
+### App configuration
+
+Create `packaging/home-assistant/config.yaml` with at least the following design:
+
+- name `Popcorn Vote` and a stable `popcorn_vote` slug;
+- version matching the immutable image tag, bumped only after that tag is
+  pullable (see Phase 4, Release ordering);
+- `amd64` and `aarch64` architecture declarations;
+- generic multi-architecture image name
+  `ghcr.io/stadicus/popcorn-vote`;
+- `3000/tcp` published as host port 3000 by default and editable through the
+  Home Assistant network settings;
+- `webui: http://[HOST]:[PORT:3000]`;
+- watchdog URL ending in `/healthz`;
+- automatic boot as an application service;
+- `backup: cold` for a consistent SQLite snapshot;
+- no options schema because setup belongs to Popcorn Vote;
+- experimental stage for the initial release;
+- no Ingress, host network, Home Assistant API, Supervisor API, devices,
+  privileged capabilities, or unrelated directory mappings.
+
+The Home Assistant `/data/options.json` file may coexist with Popcorn Vote data.
+Popcorn Vote reads its own `/data/config.yaml` explicitly and must ignore the
+Supervisor file.
+
+### Platform facts (verified)
+
+Two load-bearing platform behaviours carry the repository layout and the Phase 4
+release workflow changes. Both are resolved against the current official Home
+Assistant developer documentation
+(<https://developers.home-assistant.io/docs/apps/configuration/>, checked
+2026-08-15) rather than assumed:
+
+1. **Recursive app discovery — supported.** The Supervisor scans an app
+   repository recursively for `config.yaml`, so
+   `packaging/home-assistant/config.yaml` is discovered two directory levels
+   deep even though the repository root also carries the full application tree.
+   The layout in the Repository Layout section therefore stands. One
+   check remains, because it is repository-specific rather than a platform
+   question: no other `config.yaml` in the tree (application fixtures, packaging
+   files, test data) may be misdetectable as a second app. If a collision
+   exists, resolve it by narrowing the conflicting filename, not by moving the
+   app.
+
+   This is **not** a one-time implementation check. A fixture added six months
+   from now would re-create the collision silently, and the Supervisor would
+   publish it as a second app. `packaging/check.sh` therefore enforces it as a
+   standing invariant: any store-discoverable file (see "recognized package
+   file" in Phase 5) outside the canonical package paths is a hard failure. The
+   fix is always to rename or reshape the offending file, never to suppress the
+   check.
+
+2. **Generic multi-architecture image — supported, labels required.** The
+   Supervisor accepts a single generic multi-architecture manifest image
+   (`ghcr.io/stadicus/popcorn-vote`) without the `{arch}` naming scheme. Because
+   this image is built by the project's own release workflow rather than by
+   `home-assistant/builder`, the `io.hass.version`, `io.hass.type`, and
+   `io.hass.arch` labels are **required**, not optional. The Phase 4 label work
+   is therefore unconditional. The per-architecture `{arch}` naming scheme is
+   not a fallback for this plan: supporting Supervisor versions old enough to
+   need it is not a requirement of this delivery, and the first release targets
+   current Home Assistant OS.
+
+Where this plan asserts a platform requirement, the assertion carries its source.
+Implementation applies the same standard to the Unraid claims it acts on
+(the absence of an architecture field in the template schema and update behavior
+through a moving tag). The successful submission scan recorded in
+`packaging/README.md` is the observed source for nested template and maintainer
+profile discovery.
+
+### Presentation and documentation
+
+- Provide an app icon and logo derived from existing project artwork.
+- Provide English and German network descriptions.
+- Explain installation of the custom repository and opening the web UI.
+- Document `homeassistant.local`, direct IP, and custom host-port access.
+- State that users must not forward the direct HTTP port from their router.
+- Recommend a VPN for remote access.
+- Explain that plain HTTP on a trusted LAN does not provide transport
+  encryption and that reliable PWA installation generally requires HTTPS.
+- Document startup, update, backup, restore, and uninstall behavior.
+- Document the ownership self-heal and how to re-arm it. The entrypoint adopts
+  `/data` once and records that in `/data/.ownership-migrated`; it does not run
+  again while that marker exists. If `/data` contents are replaced or re-owned
+  from outside the container — copying a backup in as root on plain Docker is
+  the realistic case — the application fails with permission errors and the
+  self-heal stays off silently. The fix is one line for the user: delete
+  `/data/.ownership-migrated` and restart, which re-runs the one-time migration.
+  This belongs in the Docker/Compose documentation as well, not only in the
+  Home Assistant app docs.
+- State explicitly that the first release does not support Ingress.
+- Add a `home-assistant/` row to the store-package table in the existing
+  top-level `packaging/README.md`, which today carries a single `unraid/` row
+  (status `shipped`). The row describes how this package ships — discovered by a
+  custom Home Assistant repository scan, not submitted as a pull request to an
+  upstream store — consistent with how the `unraid/` row describes its delivery
+  mechanism. Umbrel and CasaOS get their rows when their packages land.
+
+## Phase 3: Remaining Platform Packages
+
+### Unraid
+
+`packaging/unraid/popcorn-vote.xml` (Community Applications template),
+`packaging/unraid/ca_profile.xml` (maintainer profile), `packaging/README.md`,
+`packaging/check.sh`, and `packaging/test-install.sh` already exist on branch
+`main` (squash commit `0bf3f08`) — see "Existing baseline" in the Status
+section. Implementation corrects them in place through ordinary follow-up pull
+requests, against `main` as it stands at that moment.
+
+**Preserve the uid fix.** The corrections below touch the same template the
+branch already fixed. `<ExtraParams>--user 99:100</ExtraParams>` and its
+explanatory comment must survive the rewrite unchanged — see "Container user on
+Unraid" below. A "correct in place" pass that silently drops it reintroduces the
+`EACCES` crash-loop that fix removed.
+
+Required corrections to the committed baseline:
+
+- **Moving tag — deliberate Unraid exception, keep `:latest`.**
+  `packaging/unraid/popcorn-vote.xml` sets
+  `<Repository>ghcr.io/stadicus/popcorn-vote:latest</Repository>`, and it keeps
+  it. Unraid's update model is structurally different from the other three
+  stores: dockerMan copies the template to the user's flash drive at install
+  time and detects updates by comparing the local against the remote digest of
+  the **referenced tag**. A repo-side tag bump therefore never reaches an
+  existing install, and a pinned immutable tag never changes digest — every
+  Unraid user would be frozen at the version they installed, with no update
+  indicator. Home Assistant, Umbrel, and CasaOS propagate updates through store
+  metadata refresh, so pinning is correct there and stays mandatory. This is why
+  effectively every mature Community Applications template (linuxserver, binhex,
+  hotio) references a moving tag. The exception is recorded in the Shared
+  Container Contract table and scoped out of the Phase 5 pinning check.
+- **Profile location and schema — verified.** The Community Applications
+  submission scan reported that `ca_profile.xml` was found and its profile
+  content extracted at `packaging/unraid/ca_profile.xml`. Keep the accepted
+  location and `<Maintainer>` schema.
+- **Architecture handling.** The public Unraid Community Applications template
+  XML schema has no architecture field, so the template cannot declare supported
+  CPU architectures. Multi-architecture compatibility comes from the published
+  image's OCI manifest instead: document `linux/amd64` and `linux/arm64` in the
+  template's description prose and in `packaging/README.md`, and verify the claim
+  by inspecting the published manifest (Phase 5) rather than by validating a
+  non-existent XML field.
+
+The template must additionally:
+
+- use the published image at the moving `latest` tag, per the documented
+  Unraid exception above — not a pinned release tag;
+- expose container port 3000 with a configurable host port;
+- map a user-selected persistent directory to `/data`;
+- link to the project documentation, source, icon, and support location;
+- describe the optional environment variables without requiring them;
+- avoid privileged mode and unnecessary host paths;
+- default to a local-network Web UI URL.
+
+- **Container user on Unraid — keep `--user 99:100`.** The template passes
+  `<ExtraParams>--user 99:100</ExtraParams>`, and it keeps it. This is a
+  deliberate decision, not an accident of the baseline: Unraid creates appdata
+  as `nobody:users` (99:100), and every other container on that share follows
+  the same convention, so the operator's backup tooling and file access keep
+  working. `packaging/test-install.sh` encodes this as a contract by asserting
+  that `popcornvote.sqlite` ends up owned `99:100`.
+
+  Consequence for Phase 1: on Unraid the container starts as 99:100, which is
+  non-root, so it takes Phase 1 step 4's direct-exec path. The entrypoint
+  performs no ownership change and there is no root window on Unraid at all —
+  the mount is already owned by the user the process runs as. Root-then-drop is
+  required for Home Assistant, where the Supervisor owns the `/data` mount and
+  the package cannot choose the uid. It is not required only where the platform
+  supplies a uid convention the mount already follows — Unraid alone. Umbrel and
+  CasaOS permit a Compose `user:` directive but publish no such convention, so
+  they keep root-then-drop; see Phase 1(d). Removing the flag would make the entrypoint `chown`
+  a user's appdata directory to uid 1000, against Unraid convention and against
+  what `test-install.sh` asserts.
+
+- **Template discovery — verified.** The submission scan accepted the nested
+  `packaging/unraid/popcorn-vote.xml`. Keep its path and `TemplateURL`.
+
+Keep the successful discovery result and update mechanism recorded in
+`packaging/README.md`.
+
+The external submission step is the Community Applications submission portal at
+<https://ca.unraid.net/submit>, which is the current source of truth (checked
+2026-08-15; see also the official starter repository
+<https://github.com/unraid/unraid-community-apps-starter>). The procedure is
+Validate, then Scan, then submit the repository through the portal — not a
+forum post or a direct appFeed registration with a maintainer, which is the
+obsolete process. `packaging/README.md` on `main` already documents this portal flow — that
+correction landed upstream and needs no repeat. Verify it still reads correctly
+when extending the file. Performing the submission itself requires explicit
+authorization under Autonomous Execution Boundaries.
+
+### Umbrel
+
+Create `packaging/umbrel/umbrel-app.yml` and its matching
+`packaging/umbrel/docker-compose.yml` as review-ready sources for an upstream
+`getumbrel/umbrel-apps` contribution.
+
+The pair must:
+
+- pin the image by multi-architecture digest, not by tag alone: image references
+  take the form `ghcr.io/stadicus/popcorn-vote:<version>@sha256:<digest>`, where
+  the digest is that of the multi-architecture manifest list (not of a single
+  architecture's image). Umbrel's upstream review expects digest-pinned images;
+  an immutable version tag on its own does not satisfy it;
+- use Umbrel's expected app-network and Web UI conventions;
+- persist `/data` in the platform-provided app data directory;
+- expose only the application HTTP port;
+- include health checking where supported;
+- contain no secrets or sample API keys.
+
+Do not open an upstream pull request without explicit authorization.
+
+### CasaOS
+
+Create `packaging/casaos/docker-compose.yml` using the CasaOS Compose extension
+metadata expected by its application installer.
+
+It must:
+
+- use the same immutable image release as the Home Assistant and Umbrel
+  packages — pinned to the version tag, not `latest` (the moving-tag exception
+  is Unraid's alone);
+- provide title, description, icon, Web UI, architecture, and category metadata;
+- publish a configurable host port for container port 3000;
+- persist the platform's application data directory at `/data`;
+- avoid elevated privileges and unrelated mounts.
+
+Document whether the file is intended for direct Compose import, a custom app
+store, or a later upstream submission.
+
+## Phase 4: Versioning and Publication
+
+Versioned store packages must point to an image tag that already exists or is
+published as part of the same controlled release. They must not claim that a
+moving `latest` image is an immutable store release. This applies to Home
+Assistant, Umbrel, and CasaOS. The Unraid template is the one documented
+exception (Phase 3): it deliberately references the moving tag, because that is
+how Unraid delivers updates at all, and it therefore does not advertise a
+version at all.
+
+Because `v1.2.0` already exists and its image lacks the planned Home Assistant
+runtime metadata, the first supported Home Assistant and CasaOS packages ship
+with `v1.3.0`. Umbrel remains on its already-submitted `v1.2.0` metadata until
+that same release exists, then moves to the v1.3.0 manifest-list digest alongside
+the other two stores. The bootstrap sequence below makes that binding rather
+than provisional: no new store-discoverable metadata reaches `main` before the
+image is published.
+
+The `io.hass.*` labels are **required** for this image, because it is built by
+the project's own release workflow rather than by `home-assistant/builder` — see
+Phase 2, "Platform facts (verified)", item 2. This label work is unconditional.
+
+Implementation must update the release workflow so each architecture build
+receives:
+
+- the application version as the Home Assistant build version;
+- `amd64` for `linux/amd64` and `aarch64` for `linux/arm64` as the Home Assistant
+  architecture label;
+- the existing source commit argument used for the displayed application
+  version.
+
+The final architecture-specific images must then carry valid Home Assistant image
+labels before they are combined into the generic multi-architecture manifest.
+Ordinary Docker consumers continue to use the same image.
+
+### Release ordering
+
+The release procedure must never advertise a store version before its image tag
+can be pulled. Because the store metadata lives on `main` in the same repository
+the release workflow publishes from, the mechanism is fixed here, as one ordered
+sequence, rather than left to implementation. With v1.2.0 now the baseline, the
+first release bootstraps in two repository merges around one publication:
+
+1. **Runtime and release-preparation merge.** Merge the Phase 1 entrypoint
+   change, the Phase 4 release workflow and v1.3.0 version changes, and the Phase
+   5 checks to `main` — but **not** the store-discoverable metadata for the
+   platforms that have not shipped yet. Non-discoverable metadata templates may
+   land here because no store scanner treats their filenames as packages.
+
+   Note the starting point, which is no longer a clean slate: **the Unraid
+   packaging is already on `main`** (squash commit `0bf3f08`, see "Existing
+   baseline"). `packaging/README.md`, `packaging/check.sh`,
+   `packaging/test-install.sh`, `packaging/unraid/popcorn-vote.xml`, and
+   `packaging/unraid/ca_profile.xml` are merged, uncorrected. The split below
+   therefore governs only what is still net-new:
+
+   | File | Merge | Reason |
+   | --- | --- | --- |
+   | `packaging/check.sh` extensions | step 1 | Validation tooling, discovered by no store |
+   | `packaging/test-install.sh` changes | step 1 | Store-install test, discovered by no store |
+   | `packaging/README.md` extensions | step 1 | Documentation, discovered by no store |
+   | Dockerfile, entrypoint, `release.yml`, `ci.yml` | step 1 | Runtime and workflow, no store metadata |
+   | `packaging/unraid/*` corrections | step 1 | Already on `main`; corrections make it *less* wrong, so they must not wait |
+   | `repository.yaml` | step 3 | Root file the Home Assistant Supervisor scans |
+   | `packaging/home-assistant/config.yaml` | step 3 | The app definition itself |
+   | `packaging/umbrel/*`, `packaging/casaos/*` | step 3 | Pinned to the published tag/digest |
+
+   The Unraid corrections deliberately sit in step 1 rather than step 3. Holding
+   them back would leave the already-merged, already-live template uncorrected
+   for longer with nothing gained: Unraid advertises no version (it pins
+   `:latest` by design), so correcting it cannot advertise an unpublished image.
+   The step-1/step-3 boundary exists to stop a **version claim** reaching a store
+   before its image is pullable — Unraid makes no such claim.
+
+   After step 1, no store that advertises a version can discover a Popcorn Vote
+   package, which is what prevents the plan's own contradiction of advertising
+   `v1.1.0` — an image that predates the entrypoint and the `io.hass.*` labels
+   and must never be referenced by a versioned store package.
+2. **Publish.** Run the separately authorized release workflow. It builds both
+   architectures with the new labels and
+   combines them with `imagetools create` into the multi-architecture manifest,
+   publishing `ghcr.io/stadicus/popcorn-vote:1.3.0` and refreshing `:latest`.
+3. **Metadata merge.** Only now merge the store metadata, pinned to the verified
+   `1.3.0` tag and — for Umbrel — its manifest-list digest. Discovery and
+   advertisement begin at this merge, at which point the referenced image is
+   already pullable.
+
+Every subsequent release repeats steps 2 and 3 in that order: publish first,
+then bump the store metadata in a **separate pull request opened after the
+release workflow run has succeeded**. The bump is not an automated commit pushed
+by the workflow — the release is started manually today, and an automated
+push-to-`main` step would add a second, unreviewed write path to the branch. The
+follow-up pull request is the chosen mechanism.
+
+Consequences that implementation must respect:
+
+- **`package.json` is ahead of the store metadata between steps 2 and 3.** That
+  is the normal steady state, not a drift error. The Phase 5 consistency check
+  must therefore not compare package metadata against `package.json`. It compares
+  each package file's image reference against the registry: the referenced tag
+  (and digest, where pinned) must resolve. A store metadata version behind
+  `package.json` passes; a store metadata version whose image does not resolve
+  fails.
+- **The publication gate fails closed.** Ordinary pull-request runs of
+  `packaging/check.sh` may skip registry-dependent checks when the registry is
+  unreachable (see Phase 5). Publication merges must not: they run the registry
+  checks in a required, non-skipping mode, so a registry outage turns the pull
+  request red instead of waving it through. Whether red actually *blocks* the
+  merge depends on the required-status-check configuration described in Phase 5
+  — `main` is unprotected today, so until that is configured the block is the
+  operator declining to merge red, not the platform refusing it. The trigger is mechanical, not a label —
+  it is any pull request that adds or changes the effective image reference of a
+  recognized package file (Phase 5), which covers the step-3 bootstrap merge and
+  every routine version bump after it alike.
+- The release must not silently fall back to `latest` for any store that pins
+  (Home Assistant, Umbrel, CasaOS). Unraid's deliberate exception is documented
+  in Phase 3.
+
+### Rollback and remediation
+
+Home Assistant offers no downgrade path for apps from a custom repository, so a
+defective release cannot be undone by reverting metadata:
+
+- Published version tags are never moved, retagged, or deleted. Repointing a tag
+  would change what already-installed users receive on their next update and
+  breaks the immutability the Shared Container Contract promises.
+- A defective release is remediated only by publishing a fixed higher patch
+  version and bumping the store metadata to it, following the release ordering
+  above.
+- The package documentation (Phase 2) must tell users how to recover in the
+  meantime: update to the fixed version once published, or restore the Home
+  Assistant backup taken before the update.
+
+## Phase 5: Automated Verification
+
+### Metadata checks
+
+`packaging/check.sh` is already on `main` and covers four checks today: XML
+well-formedness; that environment-variable names used in the templates are known
+to the application; that the port and data path match the container (derived
+from `docker-compose.yml`); and that `ADDRESS_HEADER` is absent from package
+defaults. Extend that script in place — do not add a second, competing
+validation script. Read the file for its current coverage before assuming this
+list is complete.
+
+Checks still missing from `packaging/check.sh` and to be added:
+
+- required files exist, including root-level `repository.yaml` once Home
+  Assistant ships, and required platform fields are present. Unraid requires
+  the scan-accepted `packaging/unraid/ca_profile.xml`;
+- package versions across the store files agree with each other and are never
+  newer than `package.json`. This is deliberately not an equality check against
+  `package.json`: between steps 2 and 3 of the Phase 4 release ordering the store
+  metadata lags by design, and a lagging-but-resolvable version must pass;
+- image repository names are identical across all packages;
+- image references are pinned for Home Assistant, Umbrel, and CasaOS: none of
+  them references the moving `latest` tag, and the Umbrel package additionally
+  references a multi-architecture manifest digest. The Unraid template is
+  exempt by design and is instead checked for the opposite: that it does
+  reference the moving tag, so the exception cannot be silently lost in a later
+  edit;
+- the image reference named in each package file resolves in the registry
+  (enforces the Phase 4 release ordering);
+- container ports are 3000 and persistent container paths are `/data` — already
+  covered today by the compose-derived check, to be extended to every package
+  format rather than written anew;
+- health endpoints use `/healthz` where the platform supports them;
+- architecture coverage: for Home Assistant and any other format with an
+  architecture field, that `amd64` and `aarch64` are declared in the platform's
+  spelling; for Unraid, which has no architecture field in its template schema,
+  that the published image's OCI manifest list contains `linux/amd64` and
+  `linux/arm64`;
+- no package enables privileged mode, host networking, or broad host mounts;
+- Home Assistant Ingress and API access remain disabled;
+- no store-discoverable file exists outside the canonical package paths. This
+  is the standing form of the Phase 2 collision check: any file matching the
+  "recognized package file" definition below — an app-shaped `config.yaml`, a
+  `<Container>`-rooted XML, a Compose file carrying store metadata — that sits
+  outside `packaging/<store>/` (or a documented root exception) is a hard
+  failure. It runs on every pull request, not once at implementation time, so a
+  fixture added later cannot silently become a second discoverable app;
+- no placeholder credentials or real secrets are present.
+
+Where package formats are YAML, parse them as YAML rather than matching text.
+Keep platform-specific semantic checks separate from the cross-platform
+invariants so failures identify the actual contract that drifted.
+
+`packaging/check.sh` is not wired into CI today. Wiring it in is in scope for
+this implementation: add it as a job or step in `.github/workflows/ci.yml` so it
+runs on every pull request, resolving the open question left in PR #18.
+
+**A red check must actually block.** `main` currently has neither branch
+protection nor a repository ruleset (verified against the GitHub API), so today
+a failing `ci.yml` job stops nothing — anyone can merge a red pull request. That
+matters here more than for an ordinary lint failure: the fail-closed registry
+gate below is the only thing standing between a registry outage and store
+metadata advertising an image nobody proved exists, and this plan's own standard
+for that gate is mechanical enforcement, not a remembered convention.
+
+Wiring `check.sh` into CI therefore includes making its job a **required status
+check on `main`**, via branch protection or a ruleset. Configuring repository
+protection is an operator action and falls under Autonomous Execution
+Boundaries: propose it, do not apply it unasked.
+
+Until that protection exists, the honest statement of the guarantee is weaker
+and the plan says so rather than overclaiming: a failed registry check **fails
+the pull request's checks, and the operator must not merge it red**. Every
+"blocks the merge" phrasing in Phase 4 and below is conditional on the required
+status check being configured.
+
+Two skip rules keep this from deadlocking the Phase 4 bootstrap. Both are
+load-bearing, because `.github/workflows/release.yml` blocks publication on a
+successful `ci.yml` conclusion for the release commit — a red `ci.yml` on `main`
+makes step 2 unreachable and the release impossible:
+
+- **Absent package files are an explicit SKIP, not a failure.** Between Phase 4
+  step 1 and step 3, `repository.yaml`, `packaging/home-assistant/config.yaml`,
+  and the Umbrel and CasaOS files are deliberately not on `main`. Every
+  per-package check — required files and
+  fields, pinning, the inverted Unraid moving-tag check, port and path checks —
+  therefore reports SKIP with a named reason when its package or metadata file is
+  wholly absent, and fails only on content that is present but malformed. A
+  package that exists must be correct; a package that does not exist yet is not
+  an error. This is what keeps `ci.yml` green on `main` between steps 1 and 3 so
+  that the release gate passes for step 2.
+- **Registry-dependent checks skip on an unreachable registry.** Image reference
+  resolution and manifest inspection degrade to a skip with an explicit message,
+  so ordinary pull requests do not fail on network conditions. The one exception
+  is the metadata-merge pull request of Phase 4 step 3, where those same checks
+  run in a required, non-skipping mode, so a registry outage turns that pull
+  request red. It blocks the merge once the required status check above is
+  configured on `main`; until then it is the operator who must not merge red.
+
+  That exception needs a mechanical trigger, not a convention: `ci.yml` runs
+  `packaging/check.sh` identically on every pull request and cannot otherwise
+  tell which one is a publication merge. The trigger is the diff itself: the
+  registry checks run as required, and may not skip, whenever a pull request
+  **adds or changes the effective image reference of any recognized package
+  file** — required or not, first publication or later bump.
+
+  **"Recognized package file" is defined by store discovery semantics, not by a
+  path list.** A fixed list of canonical paths would be exactly the wrong shape,
+  because the stores do not read paths — they scan. A file is a recognized
+  package file if a store scanner would treat it as a package:
+
+  - any YAML anywhere in the tree shaped like a Home Assistant app `config.yaml`
+    (a `slug` plus an `image` or `version` key) — the Supervisor scans
+    recursively;
+  - any XML anywhere in the tree with a Community Applications `<Container>`
+    root — the CA scan indexes the repository, not one directory;
+  - any Compose file anywhere in the tree carrying Umbrel or CasaOS store
+    metadata.
+
+  Discovery is what creates the risk, so discovery is what defines the scope. A
+  fixture or test-data `config.yaml` that happens to be app-shaped is recognized
+  precisely because the Supervisor would recognize it too.
+
+  "Effective image reference" is deliberately broader than the image string. For
+  Home Assistant the pulled tag comes from `config.yaml`'s separate `version:`
+  field, so that field is part of the reference; for Umbrel it includes the
+  `@sha256:` digest; for Unraid it is the `<Repository>` element. A change to any
+  of them is a change to what users would pull.
+
+  The trigger keys on the **package file**, not on the required-packages list,
+  and that is the point. Keying it on list membership left two holes:
+
+  - a later release bumps only a version or digest of a package that is already
+    on the list, adding no list entry; and
+  - a pull request adds a whole new package file without its list entry, so the
+    package is neither newly-required nor already-required.
+
+  Both publish an image reference no one proved resolvable. Keying on the file
+  closes both, and the required-packages list keeps its own separate job
+  (absent-file SKIP vs. FAIL, below).
+
+  The two rules reinforce each other through one invariant: **a package file
+  present in the tree must have a required-packages entry.** `packaging/check.sh`
+  enforces that directly — a package file without its entry is a hard failure,
+  not a skip — so the second hole above cannot even be merged, quite apart from
+  the registry trigger catching it. Both conditions are computable from the diff
+  against the merge base, so neither needs a human to remember a flag. One
+  implementation detail matters: `ci.yml`'s `actions/checkout` steps use the
+  default shallow fetch, which need not contain the merge base. The job that
+  computes this diff must fetch enough history (or use the pull-request base SHA
+  the event payload provides) — otherwise the diff silently comes out empty and
+  the trigger never fires, which fails open.
+
+  Push-event runs use ordinary skip-allowed registry mode. The image reference
+  was proven in the pull request; a transient registry failure on the post-merge
+  `main` run is recoverable by rerunning CI and must not permanently block the
+  manual release gate. Direct pushes to `main` are excluded by the required
+  branch-protection rule below.
+
+**The absent-file SKIP must expire.** A permanent may-be-absent rule is a
+checking hole: once a package has shipped, a deleted or renamed
+`repository.yaml` or `packaging/home-assistant/config.yaml` would keep merging
+green forever and break store discovery for every installed user. Log output is
+not a mitigation — nobody reads a green run. `packaging/check.sh` therefore
+carries an explicit **required-packages list**, versioned with the tree:
+
+- A package **absent from the tree and absent from the list** is SKIP — it has
+  not shipped yet.
+- A package **present in the tree must be on the list.** A package file without
+  its list entry is a hard failure, never a skip. This is the invariant the
+  registry trigger above leans on, and it is what stops a new package from being
+  merged into a publishable state while unlisted.
+- **Seeding.** The change that introduces the presence invariant must seed the
+  list, in the same commit, with every package already shipped in the tree at
+  that moment. Today that is the Unraid package: `packaging/unraid/*` is on
+  `main` (commit `0bf3f08`) and never passes through a step-3 metadata merge, so
+  without seeding, the step-1 pull request that adds the list mechanism would
+  hard-fail its own new check and leave `ci.yml` red on `main` — blocking the
+  release gate the whole bootstrap depends on. Unraid is therefore
+  FAIL-if-absent from step 1 onward.
+- The Phase 4 step-3 metadata merge adds each **net-new** package it ships to the
+  list **in the same commit** that adds the package files, flipping it to
+  **FAIL-if-absent**. That path governs Home Assistant, Umbrel, and CasaOS.
+- The same-commit rule binds the step-3 **merge diff against `main`**, not a
+  branch's commit history: a development branch that already carries a package
+  file must carry its list entry alongside it, and both migrate into the step-3
+  pull request together. Otherwise the presence invariant would hard-fail every
+  intermediate commit on the implementing branch.
+- After the flip, a missing required file is a hard CI failure, not a skip.
+
+This keeps `ci.yml` green between steps 1 and 3 without leaving the checks
+toothless afterwards. The registry skip stays unconditional, because a registry
+outage is an environment fault rather than a repository state — except in the
+step-3 merge, where it is required as described above.
+
+Both skip paths must print what was skipped and why.
+
+### Container smoke test
+
+Extend CI to:
+
+`packaging/test-install.sh` is already on `main` and has grown into
+a full store-install journey test: it creates a data directory owned `99:100` the
+way an app store would, starts the container with `--user 99:100`, and asserts
+that it comes up, serves `/healthz`, lands on the setup wizard, completes
+first-run setup through the API, stops offering setup afterwards, survives
+restart and update with its data intact, follows a changed host port, and
+restores from backup. Read the file for its current coverage before changing it.
+
+Keep it as its own script rather than folding it into the sequence below. The
+two overlap in steps but not in contract: `test-install.sh` exercises a
+**platform-supplied uid on a platform-owned directory** — the Phase 1 step-4
+direct-exec path — while the sequence below exercises a **root-owned directory
+the entrypoint must adopt**, the Phase 1 step-2/3 path.
+
+Which platform takes which path: **Unraid** is the only one that selects a uid
+explicitly, through the template's `--user 99:100`, so it is the step-4 case and
+`test-install.sh` is its test. **Home Assistant** cannot select one at all — the
+Supervisor owns the mount — so it is the step-2/3 case. **Umbrel and CasaOS**
+neither require nor set a Compose `user` in their package formats, so they take
+the step-2/3 root-then-drop path by default; the plan does not add a `user`
+directive for them, because there is no ownership problem to solve where the
+platform lets the container create its own data directory. The overlap
+in assertions (setup, restart, persistence) is deliberate: the same journey has
+to hold on both paths, and a regression on one path is invisible from the other.
+Where an assertion is genuinely identical, factor it into a shared helper both
+scripts call rather than deleting it from either.
+
+Extend `test-install.sh` only where the store contract changes.
+
+`test-install.sh` defaults `IMAGE` to the published
+`ghcr.io/stadicus/popcorn-vote:latest`. CI must override it with the production
+image built in the same run — otherwise a pull request tests the previously
+published image and its own regression merges green. The registry default stays
+for local use, where testing the published image is the point.
+
+Run the sequence below for **both** published architectures, each on a native
+runner: `linux/amd64` on `ubuntu-latest` and `linux/arm64` on `ubuntu-24.04-arm`.
+This matches `.github/workflows/release.yml`, which already builds one
+architecture per native runner precisely because better-sqlite3's musl source
+compile takes a multiple of the time under emulation — a cost the smoke test
+would otherwise pay on every pull request while verifying less than a native run
+does. QEMU via `docker/setup-qemu-action` is the fallback only if native ARM64
+runners are unavailable to CI. Building both architectures but exercising only
+one leaves the ARM64 image unverified, and ARM64 is the architecture most Home
+Assistant OS installations actually run.
+
+1. Build the production image.
+2. Create an isolated root-owned data directory.
+3. Start the image with that directory mounted at `/data`.
+4. Wait for `/healthz` and fail with container logs on timeout.
+5. Verify that the running Node.js process is not root.
+6. Complete first-run setup through the existing setup API using test values.
+7. Confirm that configuration and SQLite state were written under `/data`.
+8. Restart the container against the same directory.
+9. Confirm health and persistence after restart.
+10. Remove only the explicitly named test container and temporary directory,
+    for each architecture run.
+
+### Existing project checks
+
+Run the established secret scan, formatting, linting, Svelte checks, unit tests
+with coverage, production build, browser tests appropriate to the change,
+container build, and image security scan. Both release architectures must still
+build successfully.
+
+## Phase 6: Home Assistant OS Acceptance Test
+
+Before declaring the Home Assistant package stable, test it on an actual Home
+Assistant OS installation:
+
+1. Add the Git repository as a custom app repository.
+2. Confirm that Popcorn Vote appears once with the expected icon, documentation,
+   version, and experimental status.
+3. Install and start the app on the available architecture family, and record
+   which one it was.
+4. Open it through the Home Assistant Web UI button.
+5. Open it from a second LAN device using the hostname or IP and mapped port.
+6. Complete first-run setup, including a test TMDB key.
+7. Restart the app and Home Assistant and verify persistence.
+8. Change the host port in Home Assistant and verify the Web UI link and direct
+   access.
+9. Create and restore a Home Assistant backup containing the app.
+10. Inspect logs for permission, health, architecture, and shutdown errors.
+11. Verify that no Home Assistant or Supervisor token is available to the app
+    unless the platform injects one independently of requested permissions.
+
+Device testing on both architecture families is not realistic for the first
+release, so the completion criterion is narrowed rather than faked: full Home
+Assistant OS acceptance is required on **at least one** architecture family, and
+the other family is covered by the Phase 5 container smoke test, which runs
+natively on both architectures.
+The untested family stays explicitly outstanding — the app remains at
+`experimental` stage, and the app documentation and CHANGELOG name which
+architecture family has had a device test and which has not. Promotion out of
+`experimental` requires a device test on the remaining family.
+
+If no Home Assistant OS test instance is available to the autonomous
+implementation environment, all local and CI work may still complete, but the
+plan must report the device test as outstanding rather than infer success.
+
+## Acceptance Criteria
+
+The work is complete when:
+
+- all package definitions satisfy the shared container contract;
+- Popcorn Vote is installable from the custom Home Assistant repository, device-
+  tested on at least one architecture family and verified by the native Phase 5
+  smoke test on the other, with the untested family named as outstanding and the
+  app kept at `experimental` stage until it is covered;
+- the Home Assistant Web UI button resolves to the effective host port;
+- family members can access the application from the LAN without Home Assistant
+  accounts;
+- first-run setup, restart, update, and backup restore preserve `/data`;
+- the application process does not run as root after initialization;
+- no package exposes more privileges, ports, or host paths than required;
+- normal Docker and Docker Compose installations remain compatible;
+- CI and the actual Home Assistant OS acceptance test pass;
+- external submission instructions are complete and no new external submission
+  occurs without approval; the already-approved Unraid submission remains the
+  recorded baseline.
+
+## Autonomous Execution Boundaries
+
+The implementation agent may autonomously inspect and edit repository files,
+build images locally, run tests, and prepare review-ready packaging artifacts.
+It must preserve unrelated working-tree changes, especially the existing
+untracked `family-movie-night/` directory.
+
+Committing, pushing, opening a pull request, publishing images or releases,
+adding a repository to a real Home Assistant installation, submitting files to
+Unraid, Umbrel, or CasaOS, and configuring branch protection or a
+required-status-check ruleset on `main` all require the corresponding explicit
+authorization and credentials. The branch-protection change in particular may be
+proposed with the exact settings it needs (see Phase 5, "A red check must
+actually block") but must not be applied unasked — it changes who can merge what
+in this repository. When unavailable, the agent must finish all safe local work and
+report the exact remaining external action.
+
+## Review Questions
+
+External review should pay particular attention to:
+
+1. Whether a root-only ownership adjustment followed by an immediate privilege
+   drop is acceptable for all target platforms.
+2. Whether Home Assistant `cold` backup is the preferred SQLite consistency
+   tradeoff for this application.
+3. Whether the narrowed acceptance rule is the right trade — device test on one
+   architecture family, native CI smoke test on the other, `experimental` stage
+   until the second family is device-tested — or whether the release should be
+   withheld until both families have passed a device test.
+4. Whether the release ordering fixed in Phase 4 — store metadata carries the
+   last released version until the multi-arch manifest is published, then a
+   follow-up bump — is narrow and explicit enough given the manual release
+   workflow, or whether the bump must be automated and gated in the workflow
+   itself.
+5. Whether the two Phase 2 platform facts (recursive app discovery from
+   `packaging/home-assistant/`, and a generic multi-architecture image without
+   the `{arch}` naming scheme, with `io.hass.*` labels required) are read
+   correctly from the current documentation, and whether dropping the
+   per-architecture `{arch}` fallback is acceptable given the Supervisor
+   versions users actually run.
+6. Whether the Unraid corrections are complete and correctly scoped: the
+   scan-accepted nested `ca_profile.xml`, architecture support
+   documented in prose plus verified against the OCI manifest rather than
+   declared in the template XML, and the deliberate `:latest` exception for
+   Unraid alone — including whether a dedicated moving `stable` tag would be
+   preferable to `latest` for that purpose.
+7. Whether the Phase 1 threat model correctly weighs removing `USER node` — the
+   image's current hardening default — against the Supervisor-owned `/data`
+   mount that motivates it.

--- a/docs/installation-example.md
+++ b/docs/installation-example.md
@@ -22,15 +22,16 @@ home servers (`linux/arm64`). Docker pulls whichever fits the machine, so the
 1. **Get the access keys:** a TMDB key (v3, the 32-character "API key", not the
    long "read access token") and an OMDb key.
 2. **Create the folder** the app is to keep its data in, for example
-   `/srv/popcorn-vote/data`, and make it writable for UID/GID `1000`, the
-   non-root user inside the container:
+   `/srv/popcorn-vote/data`:
 
    ```sh
    sudo mkdir -p /srv/popcorn-vote/data
-   sudo chown 1000:1000 /srv/popcorn-vote/data
    ```
 
-   Everything the app ever writes lands there.
+   Everything the app ever writes lands there. On first start the container
+   adopts a root-owned folder and then runs the application as the non-root
+   user `node`. If you explicitly configure Docker's `user`, that user must
+   already be able to write the directory.
 3. **Upload the `config.yaml`:** copy `config.example.yaml` from this repository,
    enter the family members (never change the `id` values afterwards!) and put it
    into that folder as `config.yaml`. The PIN and the API keys come as

--- a/docs/website-src/index.html
+++ b/docs/website-src/index.html
@@ -690,6 +690,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -699,6 +701,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1434,7 +1437,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1456,6 +1459,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/de/index.html
+++ b/docs/website/de/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/en/index.html
+++ b/docs/website/en/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/es/index.html
+++ b/docs/website/es/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/fr/index.html
+++ b/docs/website/fr/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/it/index.html
+++ b/docs/website/it/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/ja/index.html
+++ b/docs/website/ja/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/pl/index.html
+++ b/docs/website/pl/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/pt-br/index.html
+++ b/docs/website/pt-br/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/docs/website/tr/index.html
+++ b/docs/website/tr/index.html
@@ -707,6 +707,8 @@
 				overflow: hidden;
 			}
 			.stripe p {
+				display: inline-block;
+				width: max-content;
 				margin: 0;
 				white-space: nowrap;
 				padding: 0.9rem 0;
@@ -716,6 +718,7 @@
 				letter-spacing: 0.12em;
 				text-transform: uppercase;
 				animation: marquee 26s linear infinite;
+				will-change: transform;
 			}
 			.section {
 				padding: 7rem 0;
@@ -1451,7 +1454,7 @@
 			}
 			@keyframes marquee {
 				to {
-					transform: translateX(-35%);
+					transform: translateX(-50%);
 				}
 			}
 			@keyframes spin {
@@ -1473,6 +1476,9 @@
 				}
 			}
 			@media (max-width: 720px) {
+				.stripe p {
+					animation-duration: 20s;
+				}
 				.hero {
 					padding-top: 2.4rem;
 				}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,9 @@ export default ts.config(
 			'coverage/',
 			'e2e/.data/',
 			// Working copies of the review subagents; otherwise ESLint checks the repo twice.
-			'.claude/'
+			'.claude/',
+			// Unrelated local project explicitly kept outside this repository.
+			'family-movie-night/'
 		]
 	},
 	js.configs.recommended,

--- a/messages/de.json
+++ b/messages/de.json
@@ -13,6 +13,7 @@
 	"auth.required": "PIN zuerst eingeben.",
 	"dialog.cancel": "Abbrechen",
 	"error.backToList": "Zurück zur Filmliste",
+	"error.invalidRequest": "Die Anfrage ist ungültig.",
 	"error.notFound": "Diese Seite gibt es nicht",
 	"error.notFoundHint": "Dieser Link ist vielleicht veraltet.",
 	"error.offline": "Keine Verbindung zu Popcorn Vote.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,6 +13,7 @@
 	"auth.required": "Enter the PIN first.",
 	"dialog.cancel": "Cancel",
 	"error.backToList": "Back to movie list",
+	"error.invalidRequest": "The request is invalid.",
 	"error.notFound": "Page not found",
 	"error.notFoundHint": "This link may be outdated.",
 	"error.offline": "Cannot connect to Popcorn Vote.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -13,6 +13,7 @@
 	"auth.required": "Introduce primero el PIN.",
 	"dialog.cancel": "Cancelar",
 	"error.backToList": "Volver a la lista",
+	"error.invalidRequest": "La solicitud no es válida.",
 	"error.notFound": "Página no encontrada",
 	"error.notFoundHint": "Puede que este enlace esté desactualizado.",
 	"error.offline": "No se puede conectar con Popcorn Vote.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -13,6 +13,7 @@
 	"auth.required": "Saisissez d'abord le code PIN.",
 	"dialog.cancel": "Annuler",
 	"error.backToList": "Retour à la liste",
+	"error.invalidRequest": "La requête n’est pas valide.",
 	"error.notFound": "Page introuvable",
 	"error.notFoundHint": "Ce lien est peut-être obsolète.",
 	"error.offline": "Connexion à Popcorn Vote impossible.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -13,6 +13,7 @@
 	"auth.required": "Inserisci prima il PIN.",
 	"dialog.cancel": "Annulla",
 	"error.backToList": "Torna alla lista",
+	"error.invalidRequest": "La richiesta non è valida.",
 	"error.notFound": "Pagina non trovata",
 	"error.notFoundHint": "Questo link potrebbe non essere aggiornato.",
 	"error.offline": "Impossibile connettersi a Popcorn Vote.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -13,6 +13,7 @@
 	"auth.required": "先にPINを入力してください。",
 	"dialog.cancel": "キャンセル",
 	"error.backToList": "映画リストに戻る",
+	"error.invalidRequest": "リクエストが無効です。",
 	"error.notFound": "ページが見つかりません",
 	"error.notFoundHint": "このリンクは古い可能性があります。",
 	"error.offline": "Popcorn Voteに接続できません。",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -13,6 +13,7 @@
 	"auth.required": "Najpierw wpisz PIN.",
 	"dialog.cancel": "Anuluj",
 	"error.backToList": "Wróć do listy filmów",
+	"error.invalidRequest": "Żądanie jest nieprawidłowe.",
 	"error.notFound": "Nie znaleziono strony",
 	"error.notFoundHint": "Ten link może być nieaktualny.",
 	"error.offline": "Nie można połączyć się z Popcorn Vote.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -13,6 +13,7 @@
 	"auth.required": "Digite primeiro o PIN.",
 	"dialog.cancel": "Cancelar",
 	"error.backToList": "Voltar à lista",
+	"error.invalidRequest": "A solicitação não é válida.",
 	"error.notFound": "Página não encontrada",
 	"error.notFoundHint": "Este link pode estar desatualizado.",
 	"error.offline": "Não foi possível conectar ao Popcorn Vote.",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -13,6 +13,7 @@
 	"auth.required": "Önce PIN'i gir.",
 	"dialog.cancel": "İptal",
 	"error.backToList": "Film listesine dön",
+	"error.invalidRequest": "İstek geçersiz.",
 	"error.notFound": "Sayfa bulunamadı",
 	"error.notFoundHint": "Bu bağlantı eski olabilir.",
 	"error.offline": "Popcorn Vote'a bağlanılamıyor.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1471,9 +1471,9 @@
 			}
 		},
 		"node_modules/@sveltejs/load-config": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.2.tgz",
-			"integrity": "sha512-K7dsJDQxBOF+f+epuhMactcjK2VP4MRkLKtwSykNtEI+cKVEyzrmmhQ1pmoxI800m4JKcyJ05L2M4yPwAGiBNw==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.3.tgz",
+			"integrity": "sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2614,9 +2614,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "3.22.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.22.0.tgz",
-			"integrity": "sha512-O3qn0NePTWta+1o25dIThqeEP/hEQ3VxDK2LVO8SQ5wG9umLMvulK+m1yQ4JGOb2Pkl8IB0G1lpRV/HXDXSLTQ==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.23.0.tgz",
+			"integrity": "sha512-n9jRklDqy0+W834568a4ZIZTK7DHXxvvHHxxGP8nNq7N//pOZMubttskHOquyGgfTR4Z05q2NdGNlsTpIEA48w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4579,9 +4579,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.8",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
-			"integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
+			"version": "5.56.9",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.9.tgz",
+			"integrity": "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4607,14 +4607,14 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.5.tgz",
-			"integrity": "sha512-NnkHGCTPH6k4ka1E9IpTuNv40uLArHnX52kLEuaHSGqRlPYTnkbFs529jSWG+y+wDy+v+jA2PQ0soN1umVK+OA==",
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.6.tgz",
+			"integrity": "sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"@sveltejs/load-config": "^0.2.2",
+				"@sveltejs/load-config": "^0.2.3",
 				"chokidar": "^4.0.1",
 				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "popcorn-vote",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "popcorn-vote",
-			"version": "1.2.0",
+			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"better-sqlite3": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "popcorn-vote",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"private": true,
 	"license": "MIT",
 	"type": "module",

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -23,6 +23,11 @@ pulled. After publication and the required device tests,
 `prepare-release-metadata.sh` verifies the multi-architecture image, renders the
 Home Assistant and CasaOS files, and updates Umbrel to the same version and
 manifest-list digest. It never commits, pushes, submits, or publishes anything.
+The release workflow uses a retried, best-effort post-publication inspection to
+write that digest to its job summary and the machine-readable
+`release-metadata-<version>` artifact. This avoids manual transcription from raw
+manifest output without letting a transient registry read, summary write, or
+artifact-service outage orphan an already-published image tag.
 
 The CasaOS result supports direct Compose import and is also shaped for a later
 pull request to `IceWhaleTech/CasaOS-AppStore`. Test it on a real CasaOS instance

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -14,11 +14,19 @@ package below has to be checked.
 |---|---|---|
 | `unraid/` | Unraid Community Applications | shipped |
 | `umbrel/` | Umbrel App Store | [submitted](https://github.com/getumbrel/umbrel-apps/pull/5994) |
+| `home-assistant/` | Home Assistant custom app repository | prepared for v1.3.0 |
+| `casaos/` | CasaOS direct import / later app-store contribution | prepared for v1.3.0 |
 
-CasaOS (`IceWhaleTech/CasaOS-AppStore`) is planned and not packaged yet. It also
-takes the package as a pull request against the store's own repository, and
-additionally requires it to be tested on a real CasaOS instance before
-submitting.
+Home Assistant and CasaOS metadata is held in non-discoverable templates until
+the v1.3.0 image exists. This avoids advertising an image that cannot yet be
+pulled. After publication and the required device tests,
+`prepare-release-metadata.sh` verifies the multi-architecture image, renders the
+Home Assistant and CasaOS files, and updates Umbrel to the same version and
+manifest-list digest. It never commits, pushes, submits, or publishes anything.
+
+The CasaOS result supports direct Compose import and is also shaped for a later
+pull request to `IceWhaleTech/CasaOS-AppStore`. Test it on a real CasaOS instance
+before submitting; any upstream submission requires separate authorization.
 
 ## How the Unraid package reaches users
 
@@ -115,10 +123,12 @@ application source. It verifies exactly this, and nothing beyond it: that the
 XML and the YAML parse, that every variable name a package sets is read
 somewhere in `src/`, that port and data path match the compose file, and that no
 package sets `ADDRESS_HEADER`. For the Umbrel package it additionally checks
-what only that store has: that the image is pinned to a digest, that its
-tag and the manifest version match `package.json`, that `APP_HOST` matches the
-app id, and that the data stays under `${APP_DATA_DIR}`, which is the only place
-Umbrel backs up and removes with the app.
+what only that store has: that the image is pinned to a digest, that its tag
+matches the manifest version, that the store version is not newer than
+`package.json`, that `APP_HOST` matches the app id, and that the data stays under
+`${APP_DATA_DIR}`, which is the only place Umbrel backs up and removes with the
+app. A store version behind `package.json` is expected between publishing an
+image and merging its reviewed metadata update.
 
 `test-install.sh` needs Docker and no Unraid. It creates the data directory with
 the ownership a store would give it, starts the container as the package
@@ -136,12 +146,20 @@ Unraid's, so the Umbrel package deserves its own pass:
 UIDGID=1000:1000 EXTRA='--user 1000:1000' bash packaging/test-install.sh
 ```
 
-Umbrel commonly runs on a Raspberry Pi, so the arm64 half of the image is worth
-the same attention:
+`test-root-owned-install.sh` covers the complementary app-store path used by
+Home Assistant and by Compose-based stores without a published host UID
+convention. The container adopts a root-owned mount once, leaves a platform-owned
+`options.json` alone, records `/data/.ownership-migrated`, and replaces itself
+with the application as uid 1000. If files are later copied into that directory
+as root, remove the marker and restart to repeat the migration.
+
+CI runs both install paths natively on AMD64 and ARM64. For a local ARM64 check,
+run the scripts on an ARM64 host. QEMU is a slower fallback when no such host is
+available:
 
 ```sh
 docker run --privileged --rm tonistiigi/binfmt --install arm64
-PLATFORM=linux/arm64 bash packaging/test-install.sh
+PLATFORM=linux/arm64 IMAGE=popcorn-vote:ci bash packaging/test-install.sh
 ```
 
 Emulation makes every step roughly five times slower, and `IMAGE=` picks which

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -114,8 +114,10 @@ and no file editing.
 ## Checking a package
 
 ```sh
-bash packaging/check.sh         # static: names, port, data path, XML, YAML
-bash packaging/test-install.sh  # runs the container the way a store would
+bash packaging/check.sh                  # static package contracts
+bash packaging/test-registry-required.sh # registry gate fails closed
+bash packaging/test-yaml-discovery.sh    # nested YAML stays covered
+bash packaging/test-install.sh           # exercises a store installation
 ```
 
 `check.sh` compares what the packages set against `docker-compose.yml` and the

--- a/packaging/casaos/README.md
+++ b/packaging/casaos/README.md
@@ -1,0 +1,18 @@
+# CasaOS package source
+
+`docker-compose.template.yml` is the reviewed source for the first CasaOS
+package. It is deliberately not named `docker-compose.yml` yet: the CasaOS store
+would recognize that file as publishable metadata, while the required v1.3.0
+image does not exist before the release.
+
+After the image is published and verified, `packaging/prepare-release-metadata.sh`
+materializes the pinned Compose file. The result supports direct import through
+CasaOS **Install a customised app** and is also shaped for a later contribution
+to the official CasaOS/ZimaOS app store. A real CasaOS install test is required
+before any upstream submission, and submission needs separate authorization.
+
+The default host port is 3000 and can be edited in CasaOS. Persistent state
+lives below `/DATA/AppData/$AppID/data`. The package exposes no other port,
+mount, capability, or privileged mode. Complete the unauthenticated first-run
+wizard immediately on a trusted LAN; never forward the plain-HTTP port from a
+router, and use a VPN for remote access.

--- a/packaging/casaos/docker-compose.template.yml
+++ b/packaging/casaos/docker-compose.template.yml
@@ -1,0 +1,55 @@
+name: popcorn-vote
+
+services:
+  popcorn-vote:
+    image: ghcr.io/stadicus/popcorn-vote:__VERSION__
+    restart: unless-stopped
+    ports:
+      - target: 3000
+        published: '3000'
+        protocol: tcp
+    volumes:
+      - /DATA/AppData/$AppID/data:/data
+    healthcheck:
+      test: [CMD, wget, -qO-, http://127.0.0.1:3000/healthz]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+x-casaos:
+  id: org.popcornvote.app
+  main: popcorn-vote
+  index: /
+  port_map: '3000'
+  scheme: http
+  icon: https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/static/icon-512.png
+  title:
+    en_US: Popcorn Vote
+    de_DE: Popcorn Vote
+  tagline:
+    en_US: Settle family movie night fairly
+    de_DE: Entscheidet den Familienfilmabend fair
+  description:
+    en_US: >-
+      Suggest movies, save weekly votes, and settle ties with a wheel. Complete
+      setup in the browser immediately after installing on your trusted LAN.
+    de_DE: >-
+      Filme vorschlagen, wöchentliche Stimmen sparen und Gleichstände per
+      Glücksrad lösen. Die Einrichtung direkt nach der Installation im Browser
+      im vertrauenswürdigen LAN abschließen.
+  author: Stadicus
+  developer: Stadicus
+  category: Media
+  architectures:
+    - amd64
+    - arm64
+  version: '__VERSION__'
+  update_at: '__RELEASE_DATE__'
+  release_notes:
+    en_US: First CasaOS package for Popcorn Vote __VERSION__.
+    de_DE: Erstes CasaOS-Paket für Popcorn Vote __VERSION__.
+  website: https://popcornvote.org
+  repo: https://github.com/Stadicus/popcorn-vote
+  support: https://github.com/Stadicus/popcorn-vote/issues
+  docs: https://github.com/Stadicus/popcorn-vote/blob/main/DOCUMENTATION.md

--- a/packaging/check.sh
+++ b/packaging/check.sh
@@ -187,15 +187,12 @@ if [ "$have_yaml" = 0 ]; then
 	note FAIL "node_modules/yaml is unavailable, so no YAML package can be read (run npm ci)"
 	fail=1
 else
-	for f in packaging/*/*.yml packaging/*/*.yaml; do
-		[ -e "$f" ] || continue
-		if node packaging/yaml-to-json.mjs "$f" >/dev/null 2>&1; then
-			note OK "$f"
-		else
-			note FAIL "$f"
-			fail=1
-		fi
-	done
+	yaml_results=$(bash packaging/validate-yaml.sh packaging)
+	yaml_status=$?
+	while IFS=$'\t' read -r status f; do
+		[ -n "$f" ] && note "$status" "$f"
+	done <<<"$yaml_results"
+	[ "$yaml_status" = 0 ] || fail=1
 fi
 
 echo
@@ -373,6 +370,7 @@ def validate_ha(data, expected_version):
     require(data.get('webui') == 'http://[HOST]:[PORT:3000]', 'Home Assistant webui does not follow the effective port')
     require(str(data.get('watchdog', '')).endswith('/healthz'), 'Home Assistant watchdog is not /healthz')
     require(data.get('backup') == 'cold', 'Home Assistant backup must be cold')
+    require(data.get('init') is False, 'Home Assistant must disable Supervisor init so the dropped process remains PID 1')
     require(data.get('stage') == 'experimental', 'Home Assistant must remain experimental')
     require('options' not in data and 'schema' not in data, 'Home Assistant setup must stay in the browser wizard')
     for key in ('ingress', 'host_network', 'hassio_api', 'homeassistant_api', 'docker_api', 'full_access'):
@@ -499,6 +497,7 @@ for package, ref in refs:
 PYTHON
 )
 
+resolved_versioned_digests=""
 while IFS='|' read -r package ref; do
 	[ -n "$package" ] || continue
 	inspect=""
@@ -516,6 +515,15 @@ while IFS='|' read -r package ref; do
 	fi
 
 	note OK "$package image resolves: $ref"
+	if [ "$package" != unraid ]; then
+		resolved_digest=$(awk '/^Digest:[[:space:]]+sha256:/{print $2; exit}' <<<"$inspect")
+		if [ -n "$resolved_digest" ]; then
+			resolved_versioned_digests+="$package|$resolved_digest"$'\n'
+		else
+			note FAIL "$package image did not expose a manifest-list digest"
+			fail=1
+		fi
+	fi
 	for platform in linux/amd64 linux/arm64; do
 		if grep -q "Platform:[[:space:]]*$platform" <<<"$inspect"; then
 			note OK "$package image contains $platform"
@@ -552,6 +560,16 @@ PYTHON
 		fi
 	fi
 done <<<"$registry_refs"
+
+if [ -n "$resolved_versioned_digests" ]; then
+	unique_versioned_digests=$(cut -d'|' -f2 <<<"$resolved_versioned_digests" | sed '/^$/d' | sort -u)
+	if [ "$(wc -l <<<"$unique_versioned_digests" | tr -d ' ')" = 1 ]; then
+		note OK "all reachable versioned packages resolve to one manifest-list digest"
+	else
+		note FAIL "versioned packages resolve to different manifest-list digests: $(tr '\n' ' ' <<<"$resolved_versioned_digests")"
+		fail=1
+	fi
+fi
 
 echo
 [ "$fail" = 0 ] && echo "packages consistent" || echo "PACKAGE DRIFT — see FAIL above"

--- a/packaging/check.sh
+++ b/packaging/check.sh
@@ -9,10 +9,97 @@
 #
 # What is verified is exactly what is printed below and nothing beyond it.
 set -uo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 fail=0
 note() { printf '  %-6s %s\n' "$1" "$2"; }
 
+required_packages=$(sed '/^[[:space:]]*#/d;/^[[:space:]]*$/d' packaging/required-packages.txt)
+
+required() {
+	grep -qx "$1" <<<"$required_packages"
+}
+
+version_not_newer() {
+	local candidate=$1 current=$2
+	[[ $candidate =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[[ $current =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[ "$(printf '%s\n%s\n' "$candidate" "$current" | sort -V | tail -1)" = "$current" ]
+}
+
+echo "Store discovery and shipped-package presence"
+# Recognition deliberately follows store semantics rather than only canonical
+# paths. A fixture that accidentally looks like an app is dangerous precisely
+# because the store scanner would publish it too.
+recognized=$(
+	git ls-files -co --exclude-standard -z -- '*.xml' 'config.yaml' '*/config.yaml' 'docker-compose.yml' '*/docker-compose.yml' 'umbrel-app.yml' '*/umbrel-app.yml' |
+	while IFS= read -r -d '' f; do
+		f=./$f
+		case "$f" in
+			*.xml)
+				# Recognition is intentionally more tolerant than validation: a
+				# malformed Container must be caught here and then fail the XML check,
+				# not disappear from the scanner merely because parsing failed.
+				grep -Eq '<Container([[:space:]>])' "$f" && printf '%s\n' "$f"
+				;;
+			*/config.yaml)
+				# As above, recognize the shape without requiring valid YAML. The
+				# canonical package validator is responsible for parsing it later.
+				if grep -Eq '^[[:space:]]*slug:' "$f" && grep -Eq '^[[:space:]]*(image|version):' "$f"; then
+					printf '%s\n' "$f"
+				fi
+				;;
+		*/docker-compose.yml | */umbrel-app.yml)
+			if grep -Eq '(^|[[:space:]])x-casaos:|(^|[[:space:]])x-umbrel:|umbrel-app' "$f" ||
+				{ [ "${f##*/}" = docker-compose.yml ] && [ -e "${f%/*}/umbrel-app.yml" ]; }; then
+				printf '%s\n' "$f"
+			fi
+			;;
+		esac
+	done
+)
+
+while IFS= read -r f; do
+	[ -n "$f" ] || continue
+	case "$f" in
+		./packaging/unraid/popcorn-vote.xml) package=unraid ;;
+		./packaging/home-assistant/config.yaml) package=home-assistant ;;
+		./packaging/umbrel/umbrel-app.yml | ./packaging/umbrel/docker-compose.yml) package=umbrel ;;
+		./packaging/casaos/docker-compose.yml) package=casaos ;;
+		*) note FAIL "$f is store-discoverable outside a canonical package path"; fail=1; continue ;;
+	esac
+	if required "$package"; then
+		note OK "$f belongs to shipped package $package"
+	else
+		note FAIL "$f is publishable but $package is missing from required-packages.txt"
+		fail=1
+	fi
+done <<<"$recognized"
+
+for package in unraid home-assistant umbrel casaos; do
+	case "$package" in
+		unraid) files='packaging/unraid/popcorn-vote.xml packaging/unraid/ca_profile.xml' ;;
+		home-assistant) files='repository.yaml packaging/home-assistant/config.yaml' ;;
+		umbrel) files='packaging/umbrel/umbrel-app.yml packaging/umbrel/docker-compose.yml' ;;
+		casaos) files='packaging/casaos/docker-compose.yml' ;;
+	esac
+	missing=""
+	for f in $files; do [ -e "$f" ] || missing="$missing $f"; done
+	if required "$package"; then
+		if [ -z "$missing" ]; then
+			note OK "$package required files exist"
+		else
+			note FAIL "$package is shipped but missing:$missing"
+			fail=1
+		fi
+	elif [ "$missing" = " $files" ]; then
+		note SKIP "$package has not shipped"
+	elif [ -n "$missing" ]; then
+		note FAIL "$package is partially present but missing:$missing"
+		fail=1
+	fi
+done
+
+echo
 echo "XML well-formedness"
 for f in packaging/*/*.xml; do
 	[ -e "$f" ] || continue
@@ -23,6 +110,28 @@ for f in packaging/*/*.xml; do
 		fail=1
 	fi
 done
+
+echo
+echo "Unraid image and privilege contract"
+unraid=packaging/unraid/popcorn-vote.xml
+if grep -q '<Repository>ghcr.io/stadicus/popcorn-vote:latest</Repository>' "$unraid"; then
+	note OK "Unraid follows the moving latest tag"
+else
+	note FAIL "Unraid must use ghcr.io/stadicus/popcorn-vote:latest so installed containers receive updates"
+	fail=1
+fi
+if grep -q '<ExtraParams>--user 99:100</ExtraParams>' "$unraid"; then
+	note OK "Unraid keeps its nobody:users runtime identity"
+else
+	note FAIL "Unraid must start as 99:100 to match appdata ownership"
+	fail=1
+fi
+if grep -q '<Privileged>false</Privileged>' "$unraid" && grep -q '<Network>bridge</Network>' "$unraid"; then
+	note OK "Unraid is unprivileged on a bridge network"
+else
+	note FAIL "Unraid must stay unprivileged and off the host network"
+	fail=1
+fi
 
 echo
 echo "Variable names known to the application"
@@ -71,14 +180,16 @@ done
 echo
 echo "YAML well-formedness"
 have_yaml=0
-python3 -c "import yaml" 2>/dev/null && have_yaml=1
+if [ -d node_modules/yaml ] && node packaging/yaml-to-json.mjs packaging/umbrel/umbrel-app.yml >/dev/null 2>&1; then
+	have_yaml=1
+fi
 if [ "$have_yaml" = 0 ]; then
-	note FAIL "python3 has no PyYAML, so no YAML package can be read (pip install pyyaml)"
+	note FAIL "node_modules/yaml is unavailable, so no YAML package can be read (run npm ci)"
 	fail=1
 else
-	for f in packaging/*/*.yml; do
+	for f in packaging/*/*.yml packaging/*/*.yaml; do
 		[ -e "$f" ] || continue
-		if python3 -c "import yaml,sys;yaml.safe_load(open(sys.argv[1]))" "$f" 2>/dev/null; then
+		if node packaging/yaml-to-json.mjs "$f" >/dev/null 2>&1; then
 			note OK "$f"
 		else
 			note FAIL "$f"
@@ -98,13 +209,16 @@ echo "Umbrel package matches the container"
 if [ ! -d packaging/umbrel ]; then
 	note SKIP "no packaging/umbrel directory"
 elif [ "$have_yaml" = 0 ]; then
-	note SKIP "needs PyYAML, see above"
+	note SKIP "needs node_modules/yaml, see above"
 else
 	umbrel_facts=$(python3 - <<'PYTHON' 2>/dev/null
-import json, shlex, yaml
+import json, shlex, subprocess
 
-manifest = yaml.safe_load(open('packaging/umbrel/umbrel-app.yml')) or {}
-compose = yaml.safe_load(open('packaging/umbrel/docker-compose.yml')) or {}
+def yaml_file(path):
+    return json.loads(subprocess.check_output(['node', 'packaging/yaml-to-json.mjs', path]))
+
+manifest = yaml_file('packaging/umbrel/umbrel-app.yml')
+compose = yaml_file('packaging/umbrel/docker-compose.yml')
 package = json.load(open('package.json'))
 
 services = compose.get('services') or {}
@@ -188,19 +302,22 @@ PYTHON
 		*:*) u_image_tag=${u_image_tag##*:} ;;
 		*) u_image_tag="" ;;
 		esac
-		if [ -n "$u_image_tag" ] && [ "$u_image_tag" = "$u_package_version" ]; then
-			note OK "image tag $u_image_tag matches package.json"
-		else
-			note FAIL "image tag is ${u_image_tag:-none}, package.json says ${u_package_version:-none}"
-			fail=1
-		fi
+			if [ -n "$u_image_tag" ] && [ "$u_image_tag" = "$u_version" ]; then
+				note OK "image tag $u_image_tag matches the Umbrel manifest"
+			else
+				note FAIL "image tag is ${u_image_tag:-none}, Umbrel manifest says ${u_version:-none}"
+				fail=1
+			fi
 
-		if [ -n "$u_version" ] && [ "$u_version" = "$u_package_version" ]; then
-			note OK "manifest version $u_version matches package.json"
-		else
-			note FAIL "manifest version is ${u_version:-none}, package.json says ${u_package_version:-none}"
-			fail=1
-		fi
+			# Store metadata intentionally lags package.json between image publication
+			# and the reviewed metadata bump. Equality here would make the release
+			# workflow impossible precisely during that supported window.
+			if [ -n "$u_version" ] && version_not_newer "$u_version" "$u_package_version"; then
+				note OK "manifest version $u_version is not newer than package.json $u_package_version"
+			else
+				note FAIL "manifest version ${u_version:-none} is invalid or newer than package.json ${u_package_version:-none}"
+				fail=1
+			fi
 
 		# Umbrel needs the bind-mount source to exist in the repository, and
 		# the root .gitignore has a `data/` rule that swallows it. Git never
@@ -229,6 +346,101 @@ PYTHON
 fi
 
 echo
+echo "Prepared metadata templates"
+if template_result=$(python3 - <<'PYTHON' 2>&1
+from pathlib import Path
+import json
+import re
+import subprocess
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+def yaml_file(path):
+    return json.loads(subprocess.check_output(['node', 'packaging/yaml-to-json.mjs', str(path)]))
+
+def version(value):
+    require(isinstance(value, str) and re.fullmatch(r'\d+\.\d+\.\d+', value), f'invalid version: {value!r}')
+    return tuple(map(int, value.split('.')))
+
+def validate_ha(data, expected_version):
+    require(data.get('version') == expected_version, 'Home Assistant version drifted')
+    require(data.get('slug') == 'popcorn_vote', 'Home Assistant slug drifted')
+    require(data.get('image') == 'ghcr.io/stadicus/popcorn-vote', 'Home Assistant image repository drifted')
+    require(set(data.get('arch') or []) == {'amd64', 'aarch64'}, 'Home Assistant architectures are incomplete')
+    require((data.get('ports') or {}).get('3000/tcp') == 3000, 'Home Assistant port is not 3000/tcp -> 3000')
+    require(data.get('webui') == 'http://[HOST]:[PORT:3000]', 'Home Assistant webui does not follow the effective port')
+    require(str(data.get('watchdog', '')).endswith('/healthz'), 'Home Assistant watchdog is not /healthz')
+    require(data.get('backup') == 'cold', 'Home Assistant backup must be cold')
+    require(data.get('stage') == 'experimental', 'Home Assistant must remain experimental')
+    require('options' not in data and 'schema' not in data, 'Home Assistant setup must stay in the browser wizard')
+    for key in ('ingress', 'host_network', 'hassio_api', 'homeassistant_api', 'docker_api', 'full_access'):
+        require(not data.get(key, False), f'Home Assistant must not enable {key}')
+    for key in ('privileged', 'devices', 'map'):
+        require(not data.get(key), f'Home Assistant must not request {key}')
+
+def validate_casa(data, expected_version):
+    meta = data.get('x-casaos') or {}
+    services = data.get('services') or {}
+    main_name = meta.get('main')
+    main = services.get(main_name) or {}
+    require(main_name == 'popcorn-vote', 'CasaOS main service drifted')
+    require(main.get('image') == f'ghcr.io/stadicus/popcorn-vote:{expected_version}', 'CasaOS image is not version-pinned')
+    require(set(meta.get('architectures') or []) == {'amd64', 'arm64'}, 'CasaOS architectures are incomplete')
+    require(meta.get('category') == 'Media', 'CasaOS category must use the official Media spelling')
+    require(str(meta.get('port_map')) == '3000', 'CasaOS web port is not 3000')
+    require(meta.get('version') == expected_version, 'CasaOS version drifted')
+    require(any(isinstance(p, dict) and p.get('target') == 3000 and str(p.get('published')) == '3000' for p in main.get('ports') or []), 'CasaOS port mapping drifted')
+    require('/DATA/AppData/$AppID/data:/data' in (main.get('volumes') or []), 'CasaOS data mount drifted')
+    require(not main.get('user'), 'CasaOS must use the root-then-drop entrypoint path')
+    require(not main.get('privileged', False), 'CasaOS must not be privileged')
+    require(main.get('network_mode') != 'host', 'CasaOS must not use host networking')
+    for key in ('cap_add', 'devices'):
+        require(not main.get(key), f'CasaOS must not request {key}')
+
+ha_template = yaml_file('packaging/home-assistant/config.template.yaml')
+validate_ha(ha_template, '__VERSION__')
+casa_template = yaml_file('packaging/casaos/docker-compose.template.yml')
+validate_casa(casa_template, '__VERSION__')
+
+application_version = json.loads(Path('package.json').read_text())['version']
+store_versions = []
+umbrel = yaml_file('packaging/umbrel/umbrel-app.yml')
+store_versions.append(umbrel.get('version'))
+
+ha_path = Path('packaging/home-assistant/config.yaml')
+if ha_path.exists():
+    ha = yaml_file(ha_path)
+    validate_ha(ha, ha.get('version'))
+    require(version(ha['version']) <= version(application_version), 'Home Assistant is newer than package.json')
+    store_versions.append(ha['version'])
+    repository = yaml_file('repository.yaml')
+    require(repository.get('name') and repository.get('url') and repository.get('maintainer'), 'repository.yaml is incomplete')
+    for name in ('README.md', 'DOCS.md', 'CHANGELOG.md', 'icon.png', 'logo.png'):
+        require((ha_path.parent / name).exists(), f'Home Assistant is missing {name}')
+    for name in ('README.md', 'DOCS.md', 'CHANGELOG.md'):
+        require('__' not in (ha_path.parent / name).read_text(), f'Home Assistant {name} contains an unresolved placeholder')
+
+casa_path = Path('packaging/casaos/docker-compose.yml')
+if casa_path.exists():
+    casa = yaml_file(casa_path)
+    casa_version = (casa.get('x-casaos') or {}).get('version')
+    validate_casa(casa, casa_version)
+    require(version(casa_version) <= version(application_version), 'CasaOS is newer than package.json')
+    store_versions.append(casa_version)
+
+require(len(set(store_versions)) == 1, f'versioned store packages disagree: {store_versions}')
+print('templates and any published YAML metadata satisfy the Home Assistant and CasaOS contracts')
+PYTHON
+); then
+	note OK "$template_result"
+else
+	note FAIL "$template_result"
+	fail=1
+fi
+
+echo
 echo "ADDRESS_HEADER must not be set by a package"
 # Right behind a reverse proxy, wrong for a direct install: the app would read
 # the client address from a header the caller writes, and the brute-force brake
@@ -241,6 +453,105 @@ if [ -n "$hits" ]; then
 else
 	note OK "absent from all packages"
 fi
+
+echo
+echo "Published package image references"
+registry_refs=$(python3 - <<'PYTHON' 2>/dev/null
+from pathlib import Path
+import json
+import re
+import subprocess
+
+def yaml_file(path):
+    return json.loads(subprocess.check_output(['node', 'packaging/yaml-to-json.mjs', str(path)]))
+
+refs = []
+unraid = Path('packaging/unraid/popcorn-vote.xml')
+if unraid.exists():
+    match = re.search(r'<Repository>([^<]+)</Repository>', unraid.read_text())
+    if match:
+        refs.append(('unraid', match.group(1)))
+
+ha = Path('packaging/home-assistant/config.yaml')
+if ha.exists():
+    data = yaml_file(ha)
+    if data.get('image') and data.get('version'):
+        refs.append(('home-assistant', f"{data['image']}:{data['version']}"))
+
+umbrel = Path('packaging/umbrel/docker-compose.yml')
+if umbrel.exists():
+    data = yaml_file(umbrel)
+    image = ((data.get('services') or {}).get('main') or {}).get('image')
+    if image:
+        refs.append(('umbrel', image))
+
+casaos = Path('packaging/casaos/docker-compose.yml')
+if casaos.exists():
+    data = yaml_file(casaos)
+    services = data.get('services') or {}
+    main_name = (data.get('x-casaos') or {}).get('main')
+    image = (services.get(main_name) or {}).get('image') if main_name else None
+    if image:
+        refs.append(('casaos', image))
+
+for package, ref in refs:
+    print(f'{package}|{ref}')
+PYTHON
+)
+
+while IFS='|' read -r package ref; do
+	[ -n "$package" ] || continue
+	inspect=""
+	if command -v docker >/dev/null 2>&1; then
+		inspect=$(docker buildx imagetools inspect "$ref" 2>/dev/null)
+	fi
+	if [ -z "$inspect" ]; then
+		if [ "${PACKAGING_REGISTRY_REQUIRED:-0}" = 1 ]; then
+			note FAIL "$package image $ref could not be inspected while registry validation is required"
+			fail=1
+		else
+			note SKIP "$package image $ref is unreachable; this run does not publish a package reference"
+		fi
+		continue
+	fi
+
+	note OK "$package image resolves: $ref"
+	for platform in linux/amd64 linux/arm64; do
+		if grep -q "Platform:[[:space:]]*$platform" <<<"$inspect"; then
+			note OK "$package image contains $platform"
+		else
+			note FAIL "$package image is missing $platform"
+			fail=1
+		fi
+	done
+
+	if [ "$package" = home-assistant ]; then
+		ha_version=${ref##*:}
+		image_json=$(docker buildx imagetools inspect --format '{{json .Image}}' "$ref" 2>/dev/null || true)
+		if IMAGE_JSON=$image_json python3 - "$ha_version" <<'PYTHON'
+import json
+import os
+import sys
+
+version = sys.argv[1]
+images = json.loads(os.environ['IMAGE_JSON'])
+for platform, expected_arch in [('linux/amd64', 'amd64'), ('linux/arm64', 'aarch64')]:
+    config = images[platform]['config']
+    labels = config.get('Labels') or {}
+    expected = {'io.hass.version': version, 'io.hass.type': 'app', 'io.hass.arch': expected_arch}
+    if any(labels.get(key) != value for key, value in expected.items()):
+        raise SystemExit(1)
+    if config.get('User') not in (None, '', '0', 'root'):
+        raise SystemExit(1)
+PYTHON
+		then
+			note OK "home-assistant image labels and root entrypoint are valid on both architectures"
+		else
+			note FAIL "home-assistant image labels or root entrypoint are invalid"
+			fail=1
+		fi
+	fi
+done <<<"$registry_refs"
 
 echo
 [ "$fail" = 0 ] && echo "packages consistent" || echo "PACKAGE DRIFT — see FAIL above"

--- a/packaging/home-assistant/CHANGELOG.template.md
+++ b/packaging/home-assistant/CHANGELOG.template.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## __VERSION__
+
+- First experimental Home Assistant app package.
+- Direct LAN access on an editable host port, with no Ingress or platform API
+  permissions.
+- Cold backups for consistent SQLite snapshots.
+- Native container verification on AMD64 and ARM64; Home Assistant OS device
+  acceptance completed on `__HA_TESTED_ARCH__`, with `__HA_UNTESTED_ARCH__`
+  still outstanding.

--- a/packaging/home-assistant/DOCS.template.md
+++ b/packaging/home-assistant/DOCS.template.md
@@ -1,0 +1,52 @@
+# Popcorn Vote for Home Assistant
+
+## Install and set up
+
+Add `https://github.com/Stadicus/popcorn-vote` as a custom app repository in
+Home Assistant, select **Popcorn Vote**, install it, and start it. Open the web
+interface immediately and complete the browser wizard with the first
+administrator, family members, voting rules, and the TMDB and optional OMDb
+keys.
+
+The initial wizard is unauthenticated. Install only on a trusted network and
+finish setup before another device can claim the instance. Afterwards Popcorn
+Vote protects access with its own rate-limited PIN accounts; Home Assistant
+accounts are neither required nor accepted by the app.
+
+## Network access
+
+The default address is `http://homeassistant.local:3000`. You can also use the
+Home Assistant host's IP address, for example `http://192.168.1.20:3000`. If you
+change the host port in the app's **Network** settings, use that port instead;
+the **Open Web UI** button follows the effective mapping automatically.
+
+The app serves plain HTTP directly to the LAN. Any device on that LAN can reach
+it, traffic is not encrypted, and Home Assistant Ingress is not supported in
+this release. Never forward this port from the router. Use a VPN for remote
+access. Reliable PWA installation generally needs HTTPS, which can be supplied
+by a trusted reverse proxy outside this package.
+
+## Start, update, backup, and restore
+
+The app starts automatically after Home Assistant. Updates appear when this
+custom repository publishes a newer package version. Home Assistant stops the
+app for a cold backup so its SQLite database and related files form one
+consistent snapshot. Restore that backup through Home Assistant before starting
+the app again. Uninstalling removes the app; keep a backup first if the family
+history should survive.
+
+The container adopts the Supervisor-owned `/data` directory once, leaves
+`/data/options.json` under Supervisor ownership, and records completion in
+`/data/.ownership-migrated`. If data is restored outside Home Assistant and
+copied in as root, remove that marker and restart the container to re-run the
+one-time ownership migration. Normal Home Assistant backup restore needs no
+manual ownership action.
+
+Published images are tested natively on AMD64 and ARM64. This experimental
+package additionally completed a Home Assistant OS device test on
+`__HA_TESTED_ARCH__`; `__HA_UNTESTED_ARCH__` remains the outstanding device
+family. Promotion from experimental waits for that second device test.
+
+If an update is defective, restore the backup taken before it and install the
+next fixed version when available. Published image tags are immutable and are
+never silently repointed to older content.

--- a/packaging/home-assistant/README.template.md
+++ b/packaging/home-assistant/README.template.md
@@ -1,0 +1,9 @@
+# Popcorn Vote
+
+Popcorn Vote settles family movie night with suggestions, weekly votes that can
+be saved, and a fair tie-break wheel. The whole family uses the browser-based
+setup and web interface; no Home Assistant account is needed to vote.
+
+This first Home Assistant package is experimental. It exposes Popcorn Vote
+directly on the trusted local network and does not use Ingress or the Home
+Assistant or Supervisor APIs.

--- a/packaging/home-assistant/config.template.yaml
+++ b/packaging/home-assistant/config.template.yaml
@@ -1,0 +1,19 @@
+name: Popcorn Vote
+version: '__VERSION__'
+slug: popcorn_vote
+description: Settle family movie night fairly with suggestions and saved-up votes.
+url: https://github.com/Stadicus/popcorn-vote
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/stadicus/popcorn-vote
+startup: application
+boot: auto
+stage: experimental
+backup: cold
+webui: http://[HOST]:[PORT:3000]
+watchdog: http://[HOST]:[PORT:3000]/healthz
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: Popcorn Vote web interface

--- a/packaging/home-assistant/config.template.yaml
+++ b/packaging/home-assistant/config.template.yaml
@@ -9,6 +9,7 @@ arch:
 image: ghcr.io/stadicus/popcorn-vote
 startup: application
 boot: auto
+init: false
 stage: experimental
 backup: cold
 webui: http://[HOST]:[PORT:3000]

--- a/packaging/home-assistant/repository.template.yaml
+++ b/packaging/home-assistant/repository.template.yaml
@@ -1,0 +1,3 @@
+name: Popcorn Vote apps
+url: https://github.com/Stadicus/popcorn-vote
+maintainer: Stadicus <https://github.com/Stadicus>

--- a/packaging/home-assistant/translations/de.yaml
+++ b/packaging/home-assistant/translations/de.yaml
@@ -1,0 +1,2 @@
+network:
+  3000/tcp: Popcorn-Vote-Weboberfläche

--- a/packaging/home-assistant/translations/en.yaml
+++ b/packaging/home-assistant/translations/en.yaml
@@ -1,0 +1,2 @@
+network:
+  3000/tcp: Popcorn Vote web interface

--- a/packaging/prepare-release-metadata.sh
+++ b/packaging/prepare-release-metadata.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Materialize store-discoverable metadata only after the release image exists.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: HA_TESTED_ARCH=amd64|aarch64 $0 <version> <manifest-list-digest>" >&2
+	exit 2
+fi
+
+version=$1
+digest=$2
+tested_arch=${HA_TESTED_ARCH:-}
+image=ghcr.io/stadicus/popcorn-vote
+
+[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid version: $version" >&2; exit 2; }
+[[ $digest =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "invalid digest: $digest" >&2; exit 2; }
+case $tested_arch in
+	amd64) untested_arch=aarch64 ;;
+	aarch64) untested_arch=amd64 ;;
+	*) echo "HA_TESTED_ARCH must name the Home Assistant OS device-tested family: amd64 or aarch64" >&2; exit 2 ;;
+esac
+
+cd "$(dirname "$0")/.."
+test "$(node -p "require('./package.json').version")" = "$version" || {
+	echo "package.json does not contain version $version" >&2
+	exit 1
+}
+
+inspect=$(docker buildx imagetools inspect "$image:$version@$digest")
+for platform in linux/amd64 linux/arm64; do
+	grep -q "Platform:[[:space:]]*$platform" <<<"$inspect" || {
+		echo "$image:$version@$digest is missing $platform" >&2
+		exit 1
+	}
+	done
+
+image_json=$(docker buildx imagetools inspect --format '{{json .Image}}' "$image:$version@$digest")
+IMAGE_JSON=$image_json python3 - "$version" <<'PYTHON'
+import json
+import os
+import sys
+
+version = sys.argv[1]
+images = json.loads(os.environ['IMAGE_JSON'])
+for platform, expected_arch in [('linux/amd64', 'amd64'), ('linux/arm64', 'aarch64')]:
+    config = images[platform]['config']
+    labels = config.get('Labels') or {}
+    expected = {
+        'io.hass.version': version,
+        'io.hass.type': 'app',
+        'io.hass.arch': expected_arch,
+    }
+    for key, value in expected.items():
+        if labels.get(key) != value:
+            raise SystemExit(f'{platform} label {key} is {labels.get(key)!r}, expected {value!r}')
+    if config.get('User') not in (None, '', '0', 'root'):
+        raise SystemExit(f'{platform} starts as {config.get("User")!r}; the ownership entrypoint cannot adopt /data')
+PYTHON
+
+render() {
+	local source=$1 target=$2
+	sed \
+		-e "s/__VERSION__/$version/g" \
+		-e "s/__DIGEST__/$digest/g" \
+		-e "s/__RELEASE_DATE__/$(date -u +%F)/g" \
+		-e "s/__HA_TESTED_ARCH__/$tested_arch/g" \
+		-e "s/__HA_UNTESTED_ARCH__/$untested_arch/g" \
+		"$source" > "$target"
+}
+
+render packaging/home-assistant/repository.template.yaml repository.yaml
+render packaging/home-assistant/config.template.yaml packaging/home-assistant/config.yaml
+render packaging/home-assistant/README.template.md packaging/home-assistant/README.md
+render packaging/home-assistant/DOCS.template.md packaging/home-assistant/DOCS.md
+render packaging/home-assistant/CHANGELOG.template.md packaging/home-assistant/CHANGELOG.md
+cp static/icon-512.png packaging/home-assistant/icon.png
+cp static/icon-512.png packaging/home-assistant/logo.png
+render packaging/casaos/docker-compose.template.yml packaging/casaos/docker-compose.yml
+
+python3 - "$version" "$digest" <<'PYTHON'
+from pathlib import Path
+import re
+import sys
+
+version, digest = sys.argv[1:]
+manifest = Path('packaging/umbrel/umbrel-app.yml')
+compose = Path('packaging/umbrel/docker-compose.yml')
+manifest.write_text(re.sub(r'(?m)^version: "[^"]+"$', f'version: "{version}"', manifest.read_text()))
+compose.write_text(re.sub(
+    r'(?m)^(\s*image: ghcr\.io/stadicus/popcorn-vote:)[^@\s]+@sha256:[0-9a-f]{64}$',
+    rf'\g<1>{version}@{digest}',
+    compose.read_text(),
+))
+PYTHON
+
+for package in home-assistant casaos; do
+	grep -qx "$package" packaging/required-packages.txt || printf '%s\n' "$package" >> packaging/required-packages.txt
+done
+
+bash packaging/check.sh
+echo "Release metadata for $version is materialized and locally validated."
+echo "Review and test it; this script does not commit, push, submit, or publish anything."

--- a/packaging/prepare-release-metadata.sh
+++ b/packaging/prepare-release-metadata.sh
@@ -26,15 +26,22 @@ test "$(node -p "require('./package.json').version")" = "$version" || {
 	exit 1
 }
 
-inspect=$(docker buildx imagetools inspect "$image:$version@$digest")
+tag_inspect=$(docker buildx imagetools inspect "$image:$version")
+tag_digest=$(awk '/^Digest:[[:space:]]+sha256:/{print $2; exit}' <<<"$tag_inspect")
+if [ "$tag_digest" != "$digest" ]; then
+	echo "$image:$version resolves to ${tag_digest:-no manifest-list digest}, not $digest" >&2
+	exit 1
+fi
+
+inspect=$(docker buildx imagetools inspect "$image@$digest")
 for platform in linux/amd64 linux/arm64; do
 	grep -q "Platform:[[:space:]]*$platform" <<<"$inspect" || {
-		echo "$image:$version@$digest is missing $platform" >&2
+		echo "$image@$digest is missing $platform" >&2
 		exit 1
 	}
 	done
 
-image_json=$(docker buildx imagetools inspect --format '{{json .Image}}' "$image:$version@$digest")
+image_json=$(docker buildx imagetools inspect --format '{{json .Image}}' "$image@$digest")
 IMAGE_JSON=$image_json python3 - "$version" <<'PYTHON'
 import json
 import os

--- a/packaging/registry-required.sh
+++ b/packaging/registry-required.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Print true when a PR changes the effective image reference of store metadata.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 <base-sha> <head-sha>" >&2
+	exit 2
+fi
+
+python3 - "$1" "$2" <<'PYTHON'
+from pathlib import PurePosixPath
+import json
+import re
+import subprocess
+import sys
+
+base, head = sys.argv[1:]
+
+def git(*args):
+    return subprocess.run(['git', *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+
+def read(revision, path):
+    result = git('show', f'{revision}:{path}')
+    return result.stdout.decode() if result.returncode == 0 else None
+
+def sibling_exists(revision, path, name):
+    sibling = str(PurePosixPath(path).parent / name)
+    return git('cat-file', '-e', f'{revision}:{sibling}').returncode == 0
+
+def yaml_text(text):
+    result = subprocess.run(
+        ['node', 'packaging/yaml-to-json.mjs', '-'],
+        input=text.encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+def effective(revision, path):
+    text = read(revision, path)
+    if text is None:
+        return None
+
+    if path.endswith('.xml') and re.search(r'<Container(?:\s|>)', text):
+        match = re.search(r'<Repository>([^<]+)</Repository>', text)
+        return ('recognized', match.group(1).strip() if match else '<invalid>')
+
+    name = PurePosixPath(path).name
+    if name == 'config.yaml' and re.search(r'(?m)^\s*slug:', text) and re.search(r'(?m)^\s*(?:image|version):', text):
+        try:
+            data = yaml_text(text)
+            return ('recognized', f"{data.get('image', '<missing>')}:{data.get('version', '<missing>')}")
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            return ('recognized', '<invalid>')
+
+    if name == 'docker-compose.yml':
+        try:
+            data = yaml_text(text)
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            if re.search(r'(?m)^\s*x-(?:casaos|umbrel):', text):
+                return ('recognized', '<invalid>')
+            return None
+        casa = data.get('x-casaos') or {}
+        is_umbrel = bool(data.get('x-umbrel')) or sibling_exists(revision, path, 'umbrel-app.yml')
+        if casa:
+            service = ((data.get('services') or {}).get(casa.get('main')) or {})
+            return ('recognized', service.get('image', '<missing>'))
+        if is_umbrel:
+            services = data.get('services') or {}
+            service = services.get('main') or next((v for k, v in services.items() if k != 'app_proxy'), {})
+            return ('recognized', service.get('image', '<missing>'))
+
+    if name == 'umbrel-app.yml':
+        return ('recognized', '<manifest-no-image>')
+    return None
+
+changed = git('diff', '--name-only', '-z', base, head).stdout.decode().split('\0')
+for path in filter(None, changed):
+    before = effective(base, path)
+    after = effective(head, path)
+    if before == after:
+        continue
+    if before is not None or after is not None:
+        # A manifest-only version edit cannot change what is pulled. Its paired
+        # Compose file must still agree, which packaging/check.sh verifies.
+        refs = {item[1] for item in (before, after) if item is not None}
+        if refs <= {'<manifest-no-image>'}:
+            continue
+        print('true')
+        raise SystemExit(0)
+
+print('false')
+PYTHON

--- a/packaging/registry-required.sh
+++ b/packaging/registry-required.sh
@@ -16,8 +16,20 @@ import sys
 
 base, head = sys.argv[1:]
 
-def git(*args):
-    return subprocess.run(['git', *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+def git(*args, check=False):
+    return subprocess.run(
+        ['git', *args],
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+for revision in (base, head):
+    try:
+        git('rev-parse', '--verify', f'{revision}^{{commit}}', check=True)
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.decode().strip()
+        raise SystemExit(f'cannot resolve Git revision {revision!r}: {detail}')
 
 def read(revision, path):
     result = git('show', f'{revision}:{path}')
@@ -75,7 +87,7 @@ def effective(revision, path):
         return ('recognized', '<manifest-no-image>')
     return None
 
-changed = git('diff', '--name-only', '-z', base, head).stdout.decode().split('\0')
+changed = git('diff', '--name-only', '-z', base, head, check=True).stdout.decode().split('\0')
 for path in filter(None, changed):
     before = effective(base, path)
     after = effective(head, path)

--- a/packaging/required-packages.txt
+++ b/packaging/required-packages.txt
@@ -1,0 +1,5 @@
+# A package in this list has shipped. Its store-discoverable files may no longer
+# disappear without failing CI. Add a package in the same metadata merge that
+# first publishes it.
+unraid
+umbrel

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -100,7 +100,15 @@ cleanup() {
 	rm -f "$PAGE" "$SETUP_OUT"
 	return "$cleanup_failed"
 }
-trap cleanup EXIT
+
+# shellcheck disable=SC2317 # Invoked indirectly by trap.
+cleanup_on_exit() {
+	local status=$1
+	trap - EXIT
+	cleanup || status=1
+	exit "$status"
+}
+trap 'cleanup_on_exit $?' EXIT
 
 echo "image:      $IMAGE"
 echo "data dir:   $DIR (owned $UIDGID, as an app store would create it)"

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -52,17 +52,53 @@ wait_for_healthz() {   # wait_for_healthz <port>, echoes the last status code
 	printf '%s' "$code"
 }
 
+remove_container() {
+	local name=$1 containers
+	for _ in 1 2 3; do
+		docker rm -f "$name" >/dev/null 2>&1 || true
+		if containers=$(docker ps -a --filter "name=^/${name}$" --format '{{.ID}}' 2>/dev/null) && [ -z "$containers" ]; then
+			return 0
+		fi
+		sleep 1
+	done
+	echo "container $name still exists after cleanup retries" >&2
+	return 1
+}
+
+remove_data_dir() {
+	local dir=$1 host_uid host_gid
+	[ -d "$dir" ] || return 0
+	host_uid=$(id -u)
+	host_gid=$(id -g)
+	for _ in 1 2 3; do
+		# App-store users own these bind mounts inside the test. Empty them as
+		# container root, restore the host owner, and require host-side removal.
+		docker run --rm -v "$dir":/x alpine:3.22 sh -c \
+			'find /x -mindepth 1 -delete; chown "$1:$2" /x' sh "$host_uid" "$host_gid" >/dev/null 2>&1 || true
+		if rmdir "$dir" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+	done
+	echo "temporary data cleanup failed: $dir" >&2
+	docker run --rm -v "$dir":/x alpine:3.22 find /x -mindepth 1 -print >&2 || true
+	return 1
+}
+
+# shellcheck disable=SC2317 # Invoked indirectly by trap.
 cleanup() {
-	docker rm -f "$NAME" "$NAME-alt" "$NAME-copy" >/dev/null 2>&1
-	docker run --rm -v "$DIR":/x alpine rm -rf /x/. >/dev/null 2>&1
-	rmdir "$DIR" 2>/dev/null
+	local cleanup_failed=0
+	for container in "$NAME" "$NAME-alt" "$NAME-copy"; do
+		remove_container "$container" || cleanup_failed=1
+	done
+	remove_data_dir "$DIR" || cleanup_failed=1
 	# Declared later in the script, so it may not exist yet when a signal
 	# arrives; without this it survived every interrupted run.
-	if [ -n "${COPY:-}" ] && [ -d "${COPY:-}" ]; then
-		docker run --rm -v "$COPY":/x alpine rm -rf /x/. >/dev/null 2>&1
-		rmdir "$COPY" 2>/dev/null
+	if [ -n "${COPY:-}" ]; then
+		remove_data_dir "$COPY" || cleanup_failed=1
 	fi
 	rm -f "$PAGE" "$SETUP_OUT"
+	return "$cleanup_failed"
 }
 trap cleanup EXIT
 
@@ -98,7 +134,12 @@ esac
 
 if [ "$fail" = 0 ]; then
 	code=$(wait_for_healthz "$PORT")
-	[ "$code" = "200" ] && echo "  OK    /healthz 200" || { echo "  FAIL  /healthz $code"; fail=1; }
+	if [ "$code" = "200" ]; then
+		echo "  OK    /healthz 200"
+	else
+		echo "  FAIL  /healthz $code"
+		fail=1
+	fi
 
 	# The whole point of an app store package: a browser lands on something
 	# actionable, with no shell and no file editing.
@@ -111,7 +152,12 @@ if [ "$fail" = 0 ]; then
 
 	# Written as the store's user, so the operator can back the directory up.
 	owner=$(docker run --rm -v "$DIR":/x alpine stat -c '%u:%g' /x/popcornvote.sqlite 2>/dev/null)
-	[ "$owner" = "$UIDGID" ] && echo "  OK    database owned $owner" || { echo "  FAIL  database owned $owner, expected $UIDGID"; fail=1; }
+	if [ "$owner" = "$UIDGID" ]; then
+		echo "  OK    database owned $owner"
+	else
+		echo "  FAIL  database owned $owner, expected $UIDGID"
+		fail=1
+	fi
 
 	# Stores show this state to their users, and compose can be told to wait for
 	# it, so an app that serves fine while reporting unhealthy is a real defect.
@@ -189,7 +235,12 @@ if [ "$fail" = 0 ]; then
 	# a consistent file behind, not a half-written one.
 	docker restart "$NAME" >/dev/null 2>&1
 	code=$(wait_for_healthz "$PORT")
-	[ "$code" = "200" ] && echo "  OK    survives a restart" || { echo "  FAIL  unhealthy after restart ($code)"; fail=1; }
+	if [ "$code" = "200" ]; then
+		echo "  OK    survives a restart"
+	else
+		echo "  FAIL  unhealthy after restart ($code)"
+		fail=1
+	fi
 
 	# Stores let people pick their own host port, and nothing in the app may
 	# assume the one from the template.
@@ -198,7 +249,12 @@ if [ "$fail" = 0 ]; then
 	docker run -d --name "$NAME-alt" $PLATFORM_ARG $EXTRA -p "$ALT_PORT":3000 -v "$DIR":/data "$IMAGE" >/dev/null 2>&1
 	alt=$(wait_for_healthz "$ALT_PORT")
 	docker rm -f "$NAME-alt" >/dev/null 2>&1
-	[ "$alt" = "200" ] && echo "  OK    works on a different host port" || { echo "  FAIL  broken on a different host port ($alt)"; fail=1; }
+	if [ "$alt" = "200" ]; then
+		echo "  OK    works on a different host port"
+	else
+		echo "  FAIL  broken on a different host port ($alt)"
+		fail=1
+	fi
 
 	# Store users back up appdata by copying it. A copy has to start elsewhere
 	# with the same ownership contract as the package under test.
@@ -219,7 +275,10 @@ if [ "$fail" = 0 ]; then
 		*)       echo "  OK    a copied data directory keeps its configuration (backup restore)" ;;
 	esac
 	docker rm -f "$NAME-copy" >/dev/null 2>&1
-	docker run --rm -v "$COPY":/x alpine rm -rf /x/. >/dev/null 2>&1; rmdir "$COPY" 2>/dev/null
+	if ! remove_container "$NAME-copy" || ! remove_data_dir "$COPY"; then
+		echo "  FAIL  copied data cleanup failed"
+		fail=1
+	fi
 fi
 
 echo

--- a/packaging/test-install.sh
+++ b/packaging/test-install.sh
@@ -200,9 +200,11 @@ if [ "$fail" = 0 ]; then
 	docker rm -f "$NAME-alt" >/dev/null 2>&1
 	[ "$alt" = "200" ] && echo "  OK    works on a different host port" || { echo "  FAIL  broken on a different host port ($alt)"; fail=1; }
 
-	# Unraid users back up appdata by copying it. A copy has to start elsewhere.
+	# Store users back up appdata by copying it. A copy has to start elsewhere
+	# with the same ownership contract as the package under test.
 	COPY=$(mktemp -d)
-	docker run --rm -v "$DIR":/from -v "$COPY":/to alpine sh -c 'cp -a /from/. /to/ && chown -R 99:100 /to' >/dev/null 2>&1
+	docker run --rm -v "$DIR":/from -v "$COPY":/to alpine \
+		sh -c 'cp -a /from/. /to/ && chown -R "$1" /to' sh "$UIDGID" >/dev/null 2>&1
 	docker rm -f "$NAME-copy" >/dev/null 2>&1
 	# shellcheck disable=SC2086
 	docker run -d --name "$NAME-copy" $PLATFORM_ARG $EXTRA -p "$COPY_PORT":3000 -v "$COPY":/data "$IMAGE" >/dev/null 2>&1

--- a/packaging/test-registry-required.sh
+++ b/packaging/test-registry-required.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Regression checks for the PR registry-validation decision.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+test "$(bash packaging/registry-required.sh HEAD HEAD)" = false
+
+for base in refs/heads/definitely-missing-registry-base refs/heads/also-missing-registry-base; do
+	if bash packaging/registry-required.sh "$base" HEAD >/dev/null 2>&1; then
+		echo "registry gate accepted missing revision $base" >&2
+		exit 1
+	fi
+done
+
+if bash packaging/registry-required.sh HEAD refs/heads/definitely-missing-registry-head >/dev/null 2>&1; then
+	echo "registry gate accepted a missing head revision" >&2
+	exit 1
+fi
+
+echo "registry validation decision fails closed"

--- a/packaging/test-root-owned-install.sh
+++ b/packaging/test-root-owned-install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Exercises the root-owned mount path used by Home Assistant and Compose stores
+# that do not declare a platform uid.
+# Unraid's explicit --user 99:100 path stays covered by test-install.sh.
+set -uo pipefail
+
+run=$$
+name=pv-root-store-test-$run
+port=${PORT:-$((4200 + run % 80))}
+image=${IMAGE:-popcorn-vote:ci}
+data_dir=$(mktemp -d)
+response=$(mktemp)
+fail=0
+
+# shellcheck disable=SC2317 # Invoked indirectly by trap.
+cleanup() {
+	docker rm -f "$name" >/dev/null 2>&1
+	docker run --rm -v "$data_dir":/x alpine:3.22 rm -rf /x/. >/dev/null 2>&1
+	rmdir "$data_dir" 2>/dev/null
+	rm -f "$response"
+}
+trap cleanup EXIT
+
+ok() { printf '  OK    %s\n' "$1"; }
+bad() { printf '  FAIL  %s\n' "$1"; fail=1; }
+
+wait_for_health() {
+	local code=""
+	for _ in $(seq 1 30); do
+		code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:$port/healthz" 2>/dev/null)
+		[ "$code" = 200 ] && return 0
+		[ "$(docker inspect --format '{{.State.Running}}' "$name" 2>/dev/null)" = true ] || return 1
+		sleep 1
+	done
+	return 1
+}
+
+echo "root-owned app-store mount"
+echo "image:    $image"
+echo "data dir: $data_dir"
+
+# options.json belongs to the Home Assistant Supervisor and remains root-only.
+# The other file represents restored application data that must be adopted.
+docker run --rm -v "$data_dir":/x alpine:3.22 \
+	sh -c 'touch /x/options.json /x/restored-data && chmod 600 /x/options.json'
+
+if docker run --rm -e DATA_DIR=/ "$image" true >/dev/null 2>&1; then
+	bad 'unsafe DATA_DIR=/ was accepted'
+else
+	ok 'unsafe DATA_DIR=/ is rejected'
+fi
+
+ln -s /data/sentinel-target "$data_dir/.ownership-migrated"
+if docker run --rm -v "$data_dir":/data "$image" true >/dev/null 2>&1 || [ -e "$data_dir/sentinel-target" ]; then
+	bad 'symbolic-link ownership marker was accepted'
+else
+	ok 'symbolic-link ownership marker is rejected without following it'
+fi
+rm -f "$data_dir/.ownership-migrated"
+
+if ! docker run -d --name "$name" -p "$port":3000 -v "$data_dir":/data "$image" >/dev/null; then
+	bad 'container did not start'
+elif wait_for_health; then
+	ok '/healthz answers on a root-owned mount'
+else
+	bad 'container did not become healthy'
+	docker logs "$name" 2>&1 | tail -10
+fi
+
+if [ "$fail" = 0 ]; then
+	pid_uid=$(docker exec "$name" sh -c "awk '/^Uid:/{print \$2}' /proc/1/status")
+	if [ "$pid_uid" = 1000 ]; then
+		ok 'PID 1 runs as node (uid 1000)'
+	else
+		bad "PID 1 runs as uid ${pid_uid:-unknown}"
+	fi
+
+	owners=$(docker run --rm -v "$data_dir":/x alpine:3.22 \
+		sh -c "stat -c '%u:%g' /x/.ownership-migrated /x/restored-data /x/options.json" 2>/dev/null)
+	expected=$(printf '1000:1000\n1000:1000\n0:0')
+	if [ "$owners" = "$expected" ]; then
+		ok 'app data is adopted while options.json stays root-owned'
+	else
+		bad "unexpected ownership: $(printf '%s' "$owners" | tr '\n' ' ')"
+	fi
+
+	setup_code=$(curl -s -o "$response" -w '%{http_code}' --max-time 20 \
+		-X POST "http://127.0.0.1:$port/api/setup" \
+		-H 'content-type: application/json' \
+		-d '{"title":"Root Mount Test","pin":"1234","confirmPin":"1234","members":["Anna","Ben"],"sources":["Server"],"tokenAmount":1,"tokenCap":5,"tokenStart":3,"tokenWeekday":1,"tokenHour":18,"timezone":"Europe/Zurich","interfaceLanguage":"en","movieLanguage":"en-US","movieFallbackLanguage":"en-US","certificationCountry":"CH","trailerLanguages":["en-US"],"tmdbApiKey":"dummy-key-for-this-test-only","omdbApiKey":""}')
+	if [ "$setup_code" = 200 ]; then
+		ok 'first-run setup completes'
+	else
+		bad "setup answered $setup_code: $(head -c 200 "$response")"
+	fi
+fi
+
+if [ "$fail" = 0 ]; then
+	docker restart "$name" >/dev/null
+	if wait_for_health; then
+		url=$(curl -sL -o /dev/null -w '%{url_effective}' --max-time 10 "http://127.0.0.1:$port/")
+		case "$url" in
+			*/setup) bad 'configuration was lost on restart' ;;
+			*) ok 'configuration and ownership migration survive restart' ;;
+		esac
+	else
+		bad 'container did not recover after restart'
+	fi
+fi
+
+if [ "$fail" = 0 ]; then
+	# A manual restore can replace files as root while the migration marker from
+	# the backup survives. The documented recovery is to remove that marker and
+	# restart, which must adopt the restored files again.
+	docker rm -f "$name" >/dev/null
+	docker run --rm -v "$data_dir":/x alpine:3.22 \
+		sh -c 'chown 0:0 /x/config.yaml /x/popcornvote.sqlite && rm /x/.ownership-migrated'
+	docker run -d --name "$name" -p "$port":3000 -v "$data_dir":/data "$image" >/dev/null
+	if wait_for_health; then
+		restored_owners=$(docker run --rm -v "$data_dir":/x alpine:3.22 \
+			sh -c "stat -c '%u:%g' /x/config.yaml /x/popcornvote.sqlite" 2>/dev/null)
+		expected=$(printf '1000:1000\n1000:1000')
+		if [ "$restored_owners" = "$expected" ]; then
+			ok 'removing the marker re-arms ownership recovery after a restore'
+		else
+			bad "restored files were not adopted: $(printf '%s' "$restored_owners" | tr '\n' ' ')"
+		fi
+	else
+		bad 'container did not recover after re-arming ownership migration'
+	fi
+fi
+
+echo
+[ "$fail" = 0 ] && echo 'root-owned app-store install works' || echo 'ROOT-OWNED APP-STORE INSTALL BROKEN'
+exit "$fail"

--- a/packaging/test-root-owned-install.sh
+++ b/packaging/test-root-owned-install.sh
@@ -14,12 +14,36 @@ fail=0
 
 # shellcheck disable=SC2317 # Invoked indirectly by trap.
 cleanup() {
-	local cleanup_fail=0
-	docker rm -f "$name" >/dev/null 2>&1 || true
-	docker run --rm -v "$data_dir":/x alpine:3.22 find /x -mindepth 1 -delete >/dev/null 2>&1 || cleanup_fail=1
-	rmdir "$data_dir" 2>/dev/null || cleanup_fail=1
+	local host_uid host_gid container_removed=0 containers
+	host_uid=$(id -u)
+	host_gid=$(id -g)
 	rm -f "$response"
-	return "$cleanup_fail"
+	for _ in 1 2 3; do
+		docker rm -f "$name" >/dev/null 2>&1 || true
+		if containers=$(docker ps -a --filter "name=^/${name}$" --format '{{.ID}}' 2>/dev/null) && [ -z "$containers" ]; then
+			container_removed=1
+			break
+		fi
+		sleep 1
+	done
+	if [ "$container_removed" = 0 ]; then
+		echo "container $name still exists after cleanup retries" >&2
+		return 1
+	fi
+	for _ in 1 2 3; do
+		# The entrypoint adopts the mount root as uid 1000. On hosted runners that
+		# differs from the host user, which cannot remove that directory from
+		# sticky /tmp even after every child is gone. Empty it as root, restore the
+		# host owner, then assert that the host can remove the mount directory.
+		docker run --rm -v "$data_dir":/x alpine:3.22 sh -c \
+			'find /x -mindepth 1 -delete; chown "$1:$2" /x' sh "$host_uid" "$host_gid" >/dev/null 2>&1 || true
+		if rmdir "$data_dir" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+	done
+	docker run --rm -v "$data_dir":/x alpine:3.22 find /x -mindepth 1 -print >&2 || true
+	return 1
 }
 trap cleanup EXIT
 

--- a/packaging/test-root-owned-install.sh
+++ b/packaging/test-root-owned-install.sh
@@ -14,10 +14,12 @@ fail=0
 
 # shellcheck disable=SC2317 # Invoked indirectly by trap.
 cleanup() {
-	docker rm -f "$name" >/dev/null 2>&1
-	docker run --rm -v "$data_dir":/x alpine:3.22 rm -rf /x/. >/dev/null 2>&1
-	rmdir "$data_dir" 2>/dev/null
+	local cleanup_fail=0
+	docker rm -f "$name" >/dev/null 2>&1 || true
+	docker run --rm -v "$data_dir":/x alpine:3.22 find /x -mindepth 1 -delete >/dev/null 2>&1 || cleanup_fail=1
+	rmdir "$data_dir" 2>/dev/null || cleanup_fail=1
 	rm -f "$response"
+	return "$cleanup_fail"
 }
 trap cleanup EXIT
 
@@ -129,6 +131,13 @@ if [ "$fail" = 0 ]; then
 		bad 'container did not recover after re-arming ownership migration'
 	fi
 fi
+
+if cleanup; then
+	ok 'temporary root-owned data was removed'
+else
+	bad "temporary data cleanup failed: $data_dir"
+fi
+trap - EXIT
 
 echo
 [ "$fail" = 0 ] && echo 'root-owned app-store install works' || echo 'ROOT-OWNED APP-STORE INSTALL BROKEN'

--- a/packaging/test-root-owned-install.sh
+++ b/packaging/test-root-owned-install.sh
@@ -10,6 +10,7 @@ port=${PORT:-$((4200 + run % 80))}
 image=${IMAGE:-popcorn-vote:ci}
 data_dir=$(mktemp -d)
 response=$(mktemp)
+locked_file=$(mktemp)
 fail=0
 
 # shellcheck disable=SC2317 # Invoked indirectly by trap.
@@ -18,6 +19,7 @@ cleanup() {
 	host_uid=$(id -u)
 	host_gid=$(id -g)
 	rm -f "$response"
+	rm -f "$locked_file"
 	for _ in 1 2 3; do
 		docker rm -f "$name" >/dev/null 2>&1 || true
 		if containers=$(docker ps -a --filter "name=^/${name}$" --format '{{.ID}}' 2>/dev/null) && [ -z "$containers" ]; then
@@ -83,6 +85,19 @@ else
 	ok 'symbolic-link ownership marker is rejected without following it'
 fi
 rm -f "$data_dir/.ownership-migrated"
+
+# A read-only nested bind mount behaves like immutable/NFS-backed content: root
+# cannot change its ownership. A partial migration must fail without recording
+# success, so the next start can retry after the operator fixes the mount.
+if docker run --rm -v "$data_dir":/data \
+	--mount "type=bind,source=$locked_file,target=/data/cannot-chown,readonly" \
+	"$image" true >/dev/null 2>&1; then
+	bad 'an ownership migration with an unchownable entry succeeded'
+elif [ -e "$data_dir/.ownership-migrated" ]; then
+	bad 'a failed ownership migration created its marker'
+else
+	ok 'failed ownership migration remains armed for retry'
+fi
 
 if ! docker run -d --name "$name" -p "$port":3000 -v "$data_dir":/data "$image" >/dev/null; then
 	bad 'container did not start'

--- a/packaging/test-yaml-discovery.sh
+++ b/packaging/test-yaml-discovery.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Prove that YAML validation reaches nested files such as HA translations.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+fixture_root=$(mktemp -d)
+mkdir -p "$fixture_root/home-assistant/translations"
+fixture="$fixture_root/home-assistant/translations/invalid.yaml"
+cleanup() {
+	rm -f "$fixture"
+	rmdir "$fixture_root/home-assistant/translations" "$fixture_root/home-assistant" "$fixture_root"
+}
+trap cleanup EXIT
+
+printf 'translation: [unterminated\n' > "$fixture"
+if output=$(bash packaging/validate-yaml.sh "$fixture_root"); then
+	echo "YAML validator accepted malformed nested YAML" >&2
+	exit 1
+fi
+
+grep -Fq $'FAIL\t'"$fixture" <<<"$output" || {
+	echo "YAML validator failed without reporting the nested fixture" >&2
+	printf '%s\n' "$output" >&2
+	exit 1
+}
+
+missing_root="$fixture_root/does-not-exist"
+if missing_output=$(bash packaging/validate-yaml.sh "$missing_root"); then
+	echo "YAML validator accepted a missing root" >&2
+	exit 1
+fi
+grep -Fq $'FAIL\t'"$missing_root" <<<"$missing_output" || {
+	echo "YAML validator did not report the missing root" >&2
+	exit 1
+}
+
+echo "nested package YAML is validated"

--- a/packaging/validate-yaml.sh
+++ b/packaging/validate-yaml.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Parse every YAML file below a directory and report one result per file.
+set -uo pipefail
+
+root=${1:-packaging}
+fail=0
+file_list=$(mktemp)
+# shellcheck disable=SC2317 # Invoked indirectly by trap.
+cleanup() {
+	rm -f "$file_list"
+}
+trap cleanup EXIT
+
+if [ ! -d "$root" ] || [ ! -r "$root" ]; then
+	printf 'FAIL\t%s (YAML root is not a readable directory)\n' "$root"
+	exit 1
+fi
+
+if ! find "$root" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 > "$file_list"; then
+	printf 'FAIL\t%s (YAML traversal failed)\n' "$root"
+	exit 1
+fi
+
+while IFS= read -r -d '' file; do
+	if node packaging/yaml-to-json.mjs "$file" >/dev/null 2>&1; then
+		printf 'OK\t%s\n' "$file"
+	else
+		printf 'FAIL\t%s\n' "$file"
+		fail=1
+	fi
+done < "$file_list"
+
+exit "$fail"

--- a/packaging/yaml-to-json.mjs
+++ b/packaging/yaml-to-json.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// One YAML parser for shell/Python packaging checks. The `yaml` package is an
+// application dependency installed by `npm ci`, unlike an implicit system-wide
+// PyYAML installation that varies between CI runner images.
+import { readFileSync } from 'node:fs';
+import YAML from 'yaml';
+
+const source = process.argv[2];
+if (!source) {
+	console.error('usage: yaml-to-json.mjs <file|->');
+	process.exit(2);
+}
+
+const text = readFileSync(source === '-' ? 0 : source, 'utf8');
+process.stdout.write(JSON.stringify(YAML.parse(text) ?? {}));

--- a/src/lib/components/Poster.svelte
+++ b/src/lib/components/Poster.svelte
@@ -55,6 +55,7 @@
 		overflow: hidden;
 		display: -webkit-box;
 		-webkit-line-clamp: 3;
+		line-clamp: 3;
 		-webkit-box-orient: vertical;
 	}
 

--- a/src/lib/components/Wheel.svelte
+++ b/src/lib/components/Wheel.svelte
@@ -8,15 +8,15 @@
 
 	const COLORS = ['#e63946', '#1d7fbf', '#2a9d8f', '#e9a11b', '#9b5de5', '#f4845f', '#00b4d8', '#ef476f'];
 
-	const n = labels.length;
-	const repeats = Math.max(2, Math.ceil(8 / n));
-	const total = n * repeats;
-	const seg = 360 / total;
-	const segments = Array.from({ length: total }, (_, s) => s % n);
+	const n = $derived(labels.length);
+	const repeats = $derived(Math.max(2, Math.ceil(8 / n)));
+	const total = $derived(n * repeats);
+	const seg = $derived(360 / total);
+	const segments = $derived(Array.from({ length: total }, (_, s) => s % n));
 
-	const winnerFields = segments.map((c, s) => ({ c, s })).filter((x) => x.c === winnerIndex);
-	const targetField = winnerFields[Math.floor(Math.random() * winnerFields.length)].s;
-	const finalAngle = 360 * 7 + (360 - (targetField * seg + seg / 2));
+	const winnerFields = $derived(segments.map((c, s) => ({ c, s })).filter((x) => x.c === winnerIndex));
+	const targetField = $derived(winnerFields[Math.floor(Math.random() * winnerFields.length)].s);
+	const finalAngle = $derived(360 * 7 + (360 - (targetField * seg + seg / 2)));
 
 	let angle = $state(0);
 	let spinning = $state(false);
@@ -58,22 +58,24 @@
 	const LABEL_INNER = 24;
 	const LABEL_OUTER = 96;
 	const LABEL_LENGTH = LABEL_OUTER - LABEL_INNER;
-	const MAX_FONT = total > 10 ? 7.5 : 9;
+	const MAX_FONT = $derived(total > 10 ? 7.5 : 9);
 	const MIN_FONT = 5.4;
 
 	const CHAR_WIDTH = 0.62; // estimated glyph width per 1 unit of font size
-	const labelSpecs = labels.map((label) => {
-		const fits = LABEL_LENGTH / (CHAR_WIDTH * Math.max(label.length, 1));
-		const fontSize = Math.max(MIN_FONT, Math.min(MAX_FONT, fits));
-		let text = label;
-		if (fits < MIN_FONT) {
-			const maxChars = Math.floor(LABEL_LENGTH / (CHAR_WIDTH * MIN_FONT));
-			text = label.slice(0, maxChars - 1).trimEnd() + '…';
-		}
-		return { text, fontSize };
-	});
+	const labelSpecs = $derived(
+		labels.map((label) => {
+			const fits = LABEL_LENGTH / (CHAR_WIDTH * Math.max(label.length, 1));
+			const fontSize = Math.max(MIN_FONT, Math.min(MAX_FONT, fits));
+			let text = label;
+			if (fits < MIN_FONT) {
+				const maxChars = Math.floor(LABEL_LENGTH / (CHAR_WIDTH * MIN_FONT));
+				text = label.slice(0, maxChars - 1).trimEnd() + '…';
+			}
+			return { text, fontSize };
+		})
+	);
 
-	const studs = Array.from({ length: total }, (_, i) => point(i * seg, 106.5));
+	const studs = $derived(Array.from({ length: total }, (_, i) => point(i * seg, 106.5)));
 </script>
 
 <div class="wrap">

--- a/src/lib/server/api.test.ts
+++ b/src/lib/server/api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { json } from '@sveltejs/kit';
 import { translator } from '$lib/i18n/translate';
-import { handled, logFailure, requirePerson, shortPath } from './api';
+import { handled, logFailure, requestJsonObject, requirePerson, shortPath } from './api';
 import { RuleError } from './game';
 import { log } from './log';
 
@@ -82,6 +82,25 @@ describe('requirePerson()', () => {
 		await expect(res.json()).resolves.toEqual({
 			error: 'Choose who you are first.'
 		});
+	});
+});
+
+describe('requestJsonObject()', () => {
+	it('returns an ordinary JSON object', async () => {
+		const request = new Request('http://localhost/api/stake', {
+			method: 'POST',
+			body: JSON.stringify({ movieId: 7 })
+		});
+		await expect(requestJsonObject(request)).resolves.toEqual({ movieId: 7 });
+	});
+
+	it.each(['{', 'null', '[]', '"text"'])('turns body %j into a translated 400', async (body) => {
+		const request = new Request('http://localhost/api/stake', { method: 'POST', body });
+		const response = await handled(locals('en'), async () =>
+			json({ body: await requestJsonObject(request) })
+		);
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({ error: 'The request is invalid.' });
 	});
 });
 

--- a/src/lib/server/api.ts
+++ b/src/lib/server/api.ts
@@ -66,6 +66,20 @@ export function requirePerson(locals: App.Locals): string {
 	return locals.personId;
 }
 
+/** Parses the JSON object every mutating API endpoint expects. */
+export async function requestJsonObject(request: Request): Promise<Record<string, unknown>> {
+	let value: unknown;
+	try {
+		value = await request.json();
+	} catch {
+		throw new RuleError('error.invalidRequest');
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		throw new RuleError('error.invalidRequest');
+	}
+	return value as Record<string, unknown>;
+}
+
 /**
  * Wraps every API handler: a broken rule becomes a 400 carrying the sentence the
  * user reads, anything else a 500 plus a log line for whoever runs the container.

--- a/src/lib/server/tmdb.test.ts
+++ b/src/lib/server/tmdb.test.ts
@@ -10,7 +10,8 @@ import {
 	extractCertification,
 	trailerChain,
 	trailerRequestLanguages,
-	pickTrailer
+	pickTrailer,
+	readPosterResponse
 } from './tmdb';
 
 // No network: `fetch` is stubbed and the answers come as fixtures from this
@@ -74,6 +75,37 @@ function answerWith(routes: (call: Call) => Record<string, unknown>) {
 }
 
 afterEach(() => vi.unstubAllGlobals());
+
+describe('poster response bounds', () => {
+	it('accepts a small supported image', async () => {
+		const response = new Response(new Uint8Array([1, 2, 3]), {
+			headers: { 'content-type': 'image/jpeg; charset=binary', 'content-length': '3' }
+		});
+		await expect(readPosterResponse(response)).resolves.toEqual(Buffer.from([1, 2, 3]));
+	});
+
+	it('rejects non-images and declared oversized responses before reading them', async () => {
+		const wrongType = new Response('not an image', { headers: { 'content-type': 'text/html' } });
+		await expect(readPosterResponse(wrongType)).resolves.toBeNull();
+
+		const oversized = new Response(new Uint8Array([1]), {
+			headers: { 'content-type': 'image/png', 'content-length': String(8 * 1024 * 1024 + 1) }
+		});
+		await expect(readPosterResponse(oversized)).resolves.toBeNull();
+	});
+
+	it('stops a chunked response once the actual body crosses the limit', async () => {
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(5 * 1024 * 1024));
+				controller.enqueue(new Uint8Array(4 * 1024 * 1024));
+				controller.close();
+			}
+		});
+		const response = new Response(stream, { headers: { 'content-type': 'image/webp' } });
+		await expect(readPosterResponse(response)).resolves.toBeNull();
+	});
+});
 
 /** Answer of the movie endpoint; poster_path stays empty, or the test would download an image. */
 function movieResponse(fields: Record<string, unknown> = {}): Record<string, unknown> {

--- a/src/lib/server/tmdb.ts
+++ b/src/lib/server/tmdb.ts
@@ -423,6 +423,8 @@ export function extractCertification(
  * put a working key out of action until the next restart.
  */
 const OMDB_REFUSES_THE_KEY = /invalid api key|no api key/i;
+const MAX_POSTER_BYTES = 8 * 1024 * 1024;
+const POSTER_MEDIA_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
 async function fetchImdbRating(config: AppConfig, imdbId: string): Promise<number | null> {
 	if (!config.omdbApiKey) return null;
@@ -453,13 +455,41 @@ async function fetchImdbRating(config: AppConfig, imdbId: string): Promise<numbe
 	}
 }
 
+/** Reads only image responses that fit comfortably in the app's poster cache. */
+export async function readPosterResponse(res: Response): Promise<Buffer | null> {
+	const mediaType = res.headers.get('content-type')?.split(';', 1)[0].trim().toLowerCase();
+	if (!mediaType || !POSTER_MEDIA_TYPES.has(mediaType)) return null;
+	const declaredRaw = res.headers.get('content-length');
+	if (declaredRaw !== null) {
+		const declared = Number(declaredRaw);
+		if (!Number.isSafeInteger(declared) || declared < 1 || declared > MAX_POSTER_BYTES) return null;
+	}
+	if (!res.body) return null;
+
+	const reader = res.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		total += value.byteLength;
+		if (total > MAX_POSTER_BYTES) {
+			await reader.cancel();
+			return null;
+		}
+		chunks.push(value);
+	}
+	return total > 0 ? Buffer.concat(chunks, total) : null;
+}
+
 async function downloadPoster(config: AppConfig, posterPath: string): Promise<string | null> {
 	try {
 		const res = await fetch(`https://image.tmdb.org/t/p/w500${posterPath}`, {
 			signal: AbortSignal.timeout(15_000)
 		});
 		if (!res.ok) return null;
-		const buffer = Buffer.from(await res.arrayBuffer());
+		const buffer = await readPosterResponse(res);
+		if (!buffer) return null;
 		// Clamped to what `/covers/[file]` will serve. TMDB delivers .jpg in
 		// practice, but an extension outside that list would be stored and then
 		// answered with a 404 by the guard there, the two ends belong together.

--- a/src/routes/api/free-pick/+server.ts
+++ b/src/routes/api/free-pick/+server.ts
@@ -1,13 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { freePick } from '$lib/server/game';
 import { toView } from '$lib/server/views';
 
 export const POST: RequestHandler = ({ request, locals }) =>
 	handled(locals, async () => {
 		const person = requirePerson(locals);
-		const { movieId } = (await request.json()) as { movieId: number };
+		const { movieId } = await requestJsonObject(request);
 		const winner = freePick(locals.db, locals.config, person, Number(movieId));
 		return json({ winner: toView(locals.db, winner) });
 	});

--- a/src/routes/api/movies/+server.ts
+++ b/src/routes/api/movies/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { findDuplicates, RuleError } from '$lib/server/game';
 import { fetchDetails } from '$lib/server/tmdb';
 import { keyProblem } from '$lib/server/keys';
@@ -19,7 +19,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 export const POST: RequestHandler = ({ request, locals }) =>
 	handled(locals, async () => {
 		const person = requirePerson(locals);
-		const body = (await request.json()) as { tmdbId?: number; title?: string; year?: number };
+		const body = await requestJsonObject(request);
 
 		let fields;
 		if (body.tmdbId) {

--- a/src/routes/api/movies/[id]/+server.ts
+++ b/src/routes/api/movies/[id]/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { deleteMovie, setProposer } from '$lib/server/game';
 
 /**
@@ -11,7 +11,7 @@ import { deleteMovie, setProposer } from '$lib/server/game';
 export const PATCH: RequestHandler = ({ request, params, locals }) =>
 	handled(locals, async () => {
 		const person = requirePerson(locals);
-		const body = (await request.json()) as { sourceHint?: string | null; proposedBy?: string };
+		const body = await requestJsonObject(request);
 		const id = Number(params.id);
 		if (body.sourceHint !== undefined) {
 			// null and the empty string clear the field. Without the null check,

--- a/src/routes/api/movies/[id]/link/+server.ts
+++ b/src/routes/api/movies/[id]/link/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { RuleError } from '$lib/server/game';
 import { fetchDetails } from '$lib/server/tmdb';
 import { keyProblem } from '$lib/server/keys';
@@ -10,7 +10,7 @@ import { log } from '$lib/server/log';
 export const POST: RequestHandler = ({ request, params, locals }) =>
 	handled(locals, async () => {
 		requirePerson(locals);
-		const { tmdbId } = (await request.json()) as { tmdbId: number };
+		const { tmdbId } = await requestJsonObject(request);
 		let d;
 		try {
 			d = await fetchDetails(locals.config, Number(tmdbId));

--- a/src/routes/api/movies/[id]/rating/+server.ts
+++ b/src/routes/api/movies/[id]/rating/+server.ts
@@ -1,12 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { rate } from '$lib/server/game';
 
 export const POST: RequestHandler = ({ request, params, locals }) =>
 	handled(locals, async () => {
 		const person = requirePerson(locals);
-		const { stars } = (await request.json()) as { stars: number };
+		const { stars } = await requestJsonObject(request);
 		rate(locals.db, locals.config, person, Number(params.id), Number(stars));
 		return json({ ok: true });
 	});

--- a/src/routes/api/person/+server.ts
+++ b/src/routes/api/person/+server.ts
@@ -1,11 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { deviceCookie } from '$lib/server/cookies';
+import { handled, requestJsonObject } from '$lib/server/api';
 
-export const POST: RequestHandler = async ({ request, cookies, locals }) => {
-	const { personId } = (await request.json()) as { personId?: string };
-	const person = locals.config.members.find((m) => m.id === personId);
-	if (!person) return json({ error: locals.t('rule.unknownPerson') }, { status: 400 });
-	cookies.set('pv_person', person.id, deviceCookie(locals.config, request.headers, { httpOnly: false }));
-	return json({ ok: true });
-};
+export const POST: RequestHandler = ({ request, cookies, locals }) =>
+	handled(locals, async () => {
+		const { personId } = await requestJsonObject(request);
+		const person = locals.config.members.find((m) => m.id === personId);
+		if (!person) return json({ error: locals.t('rule.unknownPerson') }, { status: 400 });
+		cookies.set('pv_person', person.id, deviceCookie(locals.config, request.headers, { httpOnly: false }));
+		return json({ ok: true });
+	});

--- a/src/routes/api/stake/+server.ts
+++ b/src/routes/api/stake/+server.ts
@@ -1,12 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { stake, getBalance } from '$lib/server/game';
 
 export const POST: RequestHandler = ({ request, locals }) =>
 	handled(locals, async () => {
 		const person = requirePerson(locals);
-		const { movieId, delta } = (await request.json()) as { movieId: number; delta: 1 | -1 };
+		const { movieId, delta } = await requestJsonObject(request);
 		stake(locals.db, locals.config, person, Number(movieId), delta === -1 ? -1 : 1);
 		return json({ ok: true, balance: getBalance(locals.db, person) });
 	});

--- a/src/routes/api/winner/+server.ts
+++ b/src/routes/api/winner/+server.ts
@@ -1,12 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { handled, requirePerson } from '$lib/server/api';
+import { handled, requestJsonObject, requirePerson } from '$lib/server/api';
 import { confirmWatched, revertWinner, RuleError } from '$lib/server/game';
 
 export const POST: RequestHandler = ({ request, locals }) =>
 	handled(locals, async () => {
 		const person = requirePerson(locals);
-		const { action } = (await request.json()) as { action: 'watched' | 'revert' };
+		const { action } = await requestJsonObject(request);
 		if (action === 'watched') {
 			const movie = confirmWatched(locals.db, locals.config, person);
 			return json({ ok: true, movieId: movie.id });

--- a/src/routes/tv/+page.svelte
+++ b/src/routes/tv/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { redirectIfUnauthorized } from '$lib/client/api';
 	import { detectStandalone } from '$lib/client/install.svelte';
@@ -38,12 +39,12 @@
 
 	// State machine of the TV stage: standings → (wheel) → winner celebration.
 	type Mode = 'board' | 'wheel' | 'reveal';
-	let mode: Mode = $state(data.winner ? 'reveal' : 'board');
-	let standings: Standing[] = $state(data.standings);
-	let winner: WinnerView | null = $state(data.winner);
+	let mode: Mode = $state(untrack(() => (data.winner ? 'reveal' : 'board')));
+	let standings: Standing[] = $state(untrack(() => data.standings));
+	let winner: WinnerView | null = $state(untrack(() => data.winner));
 	let wheelData: { labels: string[]; winnerIndex: number } | null = $state(null);
 	// Events already present when switching on count as seen, only new ones are celebrated.
-	let seenEventId = $state(data.lastEvent?.id ?? 0);
+	let seenEventId = $state(untrack(() => data.lastEvent?.id ?? 0));
 
 	async function poll() {
 		if (mode === 'wheel') return; // rebuild nothing while it spins


### PR DESCRIPTION
## What changed

- bump the release-ready application version to v1.3.0 and add release notes
- add a fail-closed root-owned `/data` migration followed by an immediate drop to the `node` user
- add Home Assistant labels to native AMD64/ARM64 CI and release images
- prepare non-discoverable Home Assistant and CasaOS metadata templates
- add a post-release materializer that verifies the v1.3.0 manifest, labels, architecture coverage, and digest before creating HA/CasaOS metadata and updating Umbrel
- expand packaging discovery, pinning, privilege, version-lag, and registry gates
- reject malformed or non-object JSON consistently across mutation endpoints
- bound poster downloads by media type and an 8 MiB streamed size limit
- make store-install cleanup fail closed for containers and root-owned data
- remove Svelte diagnostics, apply safe patch dependency updates, and speed up the localized marketing ticker on mobile

## Why

Home Assistant owns `/data` as root and cannot select a container uid. CasaOS has no published app-data uid convention. The existing image runs as `node` from process start and cannot adopt those mounts. At the same time, store metadata must not advertise v1.3.0 before that image exists. This PR provides the common runtime and lands only non-discoverable templates, preserving the publish-then-metadata ordering.

The additional hardening makes malformed API requests deterministic, prevents unbounded poster responses from consuming memory, proves cleanup after store-style installs, and keeps the marketing ticker's physical speed independent of viewport width.

## User impact

Existing Docker and Compose installs continue to use port 3000, `/data`, the current command, and the same environment variables. Explicit `--user` installs bypass all ownership changes. Default installs briefly start as root only to adopt `/data`, then PID 1 runs as uid 1000. Unraid remains on its established `99:100` path; the currently submitted Umbrel package remains pinned to v1.2.0 until the post-release metadata PR.

Invalid JSON mutation requests now return a consistent localized 400 response. Oversized or unsupported poster responses are rejected. The marketing ticker runs at a stable, faster speed on narrow displays while respecting reduced-motion preferences.

## Validation

- `npm run verify` (484 tests, coverage, production build, zero Svelte diagnostics, zero production audit findings)
- `bash packaging/check.sh`
- `node docs/website-src/generate.mjs --check`
- `actionlint`
- ShellCheck on all changed shell scripts
- Chromium end-to-end suite (18 tests)
- native AMD64 production image build with v1.3.0 Home Assistant labels
- root-owned install, restart, restore, uid, and verified cleanup checks
- Unraid `99:100` install/update/backup-restore journey
- Umbrel `1000:1000` install/update/backup-restore journey
- registry-required gate fixtures for package add, unrelated docs, and version bump
- negative materializer test: the existing v1.2.0 image is rejected before metadata is written because it lacks Home Assistant labels
- marketing ticker generation for all nine localized pages and responsive speed measurement

## Release and submission boundary

This PR does not publish an image or release, does not create store-discoverable Home Assistant/CasaOS metadata, and does not submit anything to a store. After merge, the separately authorized v1.3.0 release runs once. Device acceptance and the reviewed metadata PR follow against that exact manifest digest.

## Merge protection

The `main` branch now requires the complete PR CI, security, CodeQL, browser, packaging, and multi-architecture Docker check set and requires branches to be up to date before merge.
