### PR TITLE
feat(packaging): automate post-release store updates

### DIFF
--- a/.github/no-german-characters.sh
+++ b/.github/no-german-characters.sh
@@ -104,6 +104,7 @@ allow=(
 	# fields are reviewed localized UI copy, not implementation prose.
 	'^packaging/home-assistant/translations/de\.yaml:'
 	'^packaging/casaos/docker-compose\.template\.yml:'
+	'^packaging/casaos/docker-compose\.yml:'
 	# This script has to name the characters it looks for.
 	'^\.github/no-german-characters\.sh:'
 	# Native language names are shown in the language switcher.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,16 @@ jobs:
           fi
           echo "v$VERSION is new and has notes."
           echo "version_new=true" >> "$GITHUB_OUTPUT"
+      - name: Require post-release store PR credentials for a new version
+        if: steps.notes.outputs.version_new == 'true'
+        shell: bash
+        env:
+          RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PR_TOKEN" ]; then
+            echo "::error::RELEASE_PR_TOKEN is required so a new release can open its Umbrel/CasaOS update PR and trigger the protected PR checks."
+            exit 1
+          fi
 
   # One architecture per runner, each native rather than emulated: better-sqlite3
   # is compiled from source on Alpine (musl), which takes a multiple of the time
@@ -510,3 +520,138 @@ jobs:
             --target "${{ needs.gate.outputs.release_sha }}" \
             --title "$tag" \
             --notes-file "$notes"
+
+  store-metadata:
+    name: Open Umbrel and CasaOS update PR
+    if: needs.gate.outputs.publish == 'true' && needs.notes.outputs.version_new == 'true' && needs.image.outputs.published == 'true'
+    needs: [gate, notes, image, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.gate.outputs.release_sha }}
+          fetch-depth: 0
+          # The persisted GITHUB_TOKEN is read-only here and would override the
+          # PAT used below. It would also suppress follow-up CI if permissions
+          # were widened, so leave Git authentication to RELEASE_PR_TOKEN.
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - name: Resolve the published manifest digest
+        id: digest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ghcr.io/${{ github.repository }}
+          VERSION: ${{ needs.notes.outputs.version }}
+          RELEASE_SHA: ${{ needs.gate.outputs.release_sha }}
+          PUBLISHED_DIGEST: ${{ needs.image.outputs.manifest_digest }}
+        run: |
+          set -euo pipefail
+          digest=$PUBLISHED_DIGEST
+          if [ -z "$digest" ]; then
+            for attempt in 1 2 3 4 5; do
+              inspection=$(docker buildx imagetools inspect "${IMAGE,,}:$VERSION" 2>/dev/null || true)
+              digest=$(awk '/^Digest:[[:space:]]+sha256:/{print $2; exit}' <<< "$inspection")
+              [ -n "$digest" ] && break
+              [ "$attempt" -eq 5 ] || sleep 5
+            done
+          fi
+          if [[ ! $digest =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Could not resolve the published manifest digest for v$VERSION."
+            exit 1
+          fi
+          release=$(gh release view "v$VERSION" --json publishedAt,targetCommitish)
+          release_target=$(jq -r .targetCommitish <<< "$release")
+          release_date=$(jq -r '.publishedAt[0:10]' <<< "$release")
+          if [ "$release_target" != "$RELEASE_SHA" ] || [[ ! $release_date =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "::error::The published release metadata does not match source commit $RELEASE_SHA."
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "release_date=$release_date" >> "$GITHUB_OUTPUT"
+      - name: Materialize the published store metadata
+        env:
+          VERSION: ${{ needs.notes.outputs.version }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          RELEASE_DATE: ${{ steps.digest.outputs.release_date }}
+        run: bash packaging/prepare-store-update.sh "$VERSION" "$DIGEST"
+      - name: Commit, push, and open the protected update PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          VERSION: ${{ needs.notes.outputs.version }}
+          RELEASE_SHA: ${{ needs.gate.outputs.release_sha }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          branch="release/store-metadata-v$VERSION"
+          files=(
+            packaging/casaos/docker-compose.yml
+            packaging/required-packages.txt
+            packaging/umbrel/docker-compose.yml
+            packaging/umbrel/umbrel-app.yml
+          )
+
+          body="$RUNNER_TEMP/store-pr.md"
+          {
+            printf '%s\n' \
+              '## What changed' \
+              '' \
+              "- update Umbrel to v$VERSION and pin the published multi-architecture manifest" \
+              "- materialize the CasaOS v$VERSION direct-import package" \
+              '' \
+              '## Published artifact' \
+              ''
+            printf -- '- Source commit: <code>%s</code>\n' "$RELEASE_SHA"
+            printf -- '- Manifest digest: <code>%s</code>\n' "$DIGEST"
+            printf '%s\n' \
+              '' \
+              'Home Assistant remains gated on a real Home Assistant OS device acceptance test.'
+          } > "$body"
+
+          gh auth setup-git
+          if gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/$branch" --jq '.[].ref' | grep -qx "refs/heads/$branch"; then
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
+            if ! git diff --quiet "origin/$branch" -- "${files[@]}"; then
+              echo "::error::$branch already exists with different store metadata. Refusing to overwrite it."
+              exit 1
+            fi
+            existing_pr=$(gh pr list --state all --head "$branch" --json mergedAt,state,url --jq '.[0] // empty')
+            if [ -n "$existing_pr" ]; then
+              existing_url=$(jq -r .url <<< "$existing_pr")
+              existing_state=$(jq -r .state <<< "$existing_pr")
+              existing_merged=$(jq -r .mergedAt <<< "$existing_pr")
+              if [ "$existing_state" = OPEN ] || [ "$existing_merged" != null ]; then
+                echo "Store metadata PR already exists: $existing_url"
+                exit 0
+              fi
+              echo "::error::Store metadata PR $existing_url was closed without merging. Reopen it or remove $branch before retrying."
+              exit 1
+            fi
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --draft \
+              --title "Update Umbrel and CasaOS to v$VERSION" \
+              --body-file "$body"
+            exit 0
+          fi
+
+          git switch -c "$branch"
+          git config user.name github-actions
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add "${files[@]}"
+          if git diff --cached --quiet; then
+            echo "::error::The release produced no store metadata changes."
+            exit 1
+          fi
+          git commit -m "chore(packaging): update stores to v$VERSION"
+          git push origin "HEAD:refs/heads/$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --draft \
+            --title "Update Umbrel and CasaOS to v$VERSION" \
+            --body-file "$body"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -15,19 +15,29 @@ package below has to be checked.
 | `unraid/` | Unraid Community Applications | shipped |
 | `umbrel/` | Umbrel App Store | [submitted](https://github.com/getumbrel/umbrel-apps/pull/5994) |
 | `home-assistant/` | Home Assistant custom app repository | prepared for v1.3.0 |
-| `casaos/` | CasaOS direct import / later app-store contribution | prepared for v1.3.0 |
+| `casaos/` | CasaOS direct import / later app-store contribution | materialized for v1.3.0; upstream submission pending |
 
-Home Assistant and CasaOS metadata is held in non-discoverable templates until
-the v1.3.0 image exists. This avoids advertising an image that cannot yet be
-pulled. After publication and the required device tests,
-`prepare-release-metadata.sh` verifies the multi-architecture image, renders the
-Home Assistant and CasaOS files, and updates Umbrel to the same version and
-manifest-list digest. It never commits, pushes, submits, or publishes anything.
+Home Assistant metadata remains in non-discoverable templates until its required
+Home Assistant OS device test has passed. CasaOS v1.3.0 is materialized for
+direct import, while an official store submission still requires a real CasaOS
+install test and separate authorization. `prepare-release-metadata.sh` verifies
+the multi-architecture image and can render the full coordinated metadata set
+after the Home Assistant gate passes. It never commits, pushes, submits, or
+publishes anything.
 The release workflow uses a retried, best-effort post-publication inspection to
 write that digest to its job summary and the machine-readable
 `release-metadata-<version>` artifact. This avoids manual transcription from raw
 manifest output without letting a transient registry read, summary write, or
 artifact-service outage orphan an already-published image tag.
+
+Every new release also runs `prepare-store-update.sh` and opens a draft PR that
+updates Umbrel to the published manifest digest and materializes the matching
+CasaOS direct-import file. The repository secret `RELEASE_PR_TOKEN` must contain
+a fine-grained token with Contents and Pull requests read/write access. A
+personal token is required because GitHub suppresses follow-up CI for branches
+and pull requests created by the workflow's own `GITHUB_TOKEN`; the release gate
+fails before publication when this token is absent. Home Assistant is excluded
+from this automatic PR until its separate HA OS device-acceptance gate passes.
 
 The CasaOS result supports direct Compose import and is also shaped for a later
 pull request to `IceWhaleTech/CasaOS-AppStore`. Test it on a real CasaOS instance

--- a/packaging/casaos/README.md
+++ b/packaging/casaos/README.md
@@ -1,15 +1,13 @@
 # CasaOS package source
 
-`docker-compose.template.yml` is the reviewed source for the first CasaOS
-package. It is deliberately not named `docker-compose.yml` yet: the CasaOS store
-would recognize that file as publishable metadata, while the required v1.3.0
-image does not exist before the release.
+`docker-compose.template.yml` is the reviewed source for the CasaOS package.
+The released v1.3.0 image now exists, so `docker-compose.yml` is materialized as
+a directly importable, version-pinned package.
 
-After the image is published and verified, `packaging/prepare-release-metadata.sh`
-materializes the pinned Compose file. The result supports direct import through
-CasaOS **Install a customised app** and is also shaped for a later contribution
-to the official CasaOS/ZimaOS app store. A real CasaOS install test is required
-before any upstream submission, and submission needs separate authorization.
+The result supports direct import through CasaOS **Install a customised app**
+and is also shaped for a later contribution to the official CasaOS/ZimaOS app
+store. A real CasaOS install test is required before any upstream submission,
+and submission needs separate authorization.
 
 The default host port is 3000 and can be edited in CasaOS. Persistent state
 lives below `/DATA/AppData/$AppID/data`. The package exposes no other port,

--- a/packaging/casaos/docker-compose.yml
+++ b/packaging/casaos/docker-compose.yml
@@ -2,7 +2,7 @@ name: popcorn-vote
 
 services:
   popcorn-vote:
-    image: ghcr.io/stadicus/popcorn-vote:__VERSION__@__DIGEST__
+    image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
     restart: unless-stopped
     ports:
       - target: 3000
@@ -44,11 +44,11 @@ x-casaos:
   architectures:
     - amd64
     - arm64
-  version: '__VERSION__'
-  update_at: '__RELEASE_DATE__'
+  version: '1.3.0'
+  update_at: '2026-08-17'
   release_notes:
-    en_US: First CasaOS package for Popcorn Vote __VERSION__.
-    de_DE: Erstes CasaOS-Paket für Popcorn Vote __VERSION__.
+    en_US: First CasaOS package for Popcorn Vote 1.3.0.
+    de_DE: Erstes CasaOS-Paket für Popcorn Vote 1.3.0.
   website: https://popcornvote.org
   repo: https://github.com/Stadicus/popcorn-vote
   support: https://github.com/Stadicus/popcorn-vote/issues

--- a/packaging/check.sh
+++ b/packaging/check.sh
@@ -378,13 +378,13 @@ def validate_ha(data, expected_version):
     for key in ('privileged', 'devices', 'map'):
         require(not data.get(key), f'Home Assistant must not request {key}')
 
-def validate_casa(data, expected_version):
+def validate_casa(data, expected_version, expected_digest):
     meta = data.get('x-casaos') or {}
     services = data.get('services') or {}
     main_name = meta.get('main')
     main = services.get(main_name) or {}
     require(main_name == 'popcorn-vote', 'CasaOS main service drifted')
-    require(main.get('image') == f'ghcr.io/stadicus/popcorn-vote:{expected_version}', 'CasaOS image is not version-pinned')
+    require(main.get('image') == f'ghcr.io/stadicus/popcorn-vote:{expected_version}@{expected_digest}', 'CasaOS image is not pinned to the expected version and digest')
     require(set(meta.get('architectures') or []) == {'amd64', 'arm64'}, 'CasaOS architectures are incomplete')
     require(meta.get('category') == 'Media', 'CasaOS category must use the official Media spelling')
     require(str(meta.get('port_map')) == '3000', 'CasaOS web port is not 3000')
@@ -400,7 +400,7 @@ def validate_casa(data, expected_version):
 ha_template = yaml_file('packaging/home-assistant/config.template.yaml')
 validate_ha(ha_template, '__VERSION__')
 casa_template = yaml_file('packaging/casaos/docker-compose.template.yml')
-validate_casa(casa_template, '__VERSION__')
+validate_casa(casa_template, '__VERSION__', '__DIGEST__')
 
 application_version = json.loads(Path('package.json').read_text())['version']
 store_versions = []
@@ -424,7 +424,10 @@ casa_path = Path('packaging/casaos/docker-compose.yml')
 if casa_path.exists():
     casa = yaml_file(casa_path)
     casa_version = (casa.get('x-casaos') or {}).get('version')
-    validate_casa(casa, casa_version)
+    casa_image = (((casa.get('services') or {}).get('popcorn-vote') or {}).get('image') or '')
+    digest_match = re.fullmatch(rf'ghcr\.io/stadicus/popcorn-vote:{re.escape(casa_version or "")}@(sha256:[0-9a-f]{{64}})', casa_image)
+    require(digest_match is not None, 'CasaOS image is not pinned to a manifest digest')
+    validate_casa(casa, casa_version, digest_match.group(1))
     require(version(casa_version) <= version(application_version), 'CasaOS is newer than package.json')
     store_versions.append(casa_version)
 

--- a/packaging/prepare-release-metadata.sh
+++ b/packaging/prepare-release-metadata.sh
@@ -82,28 +82,8 @@ render packaging/home-assistant/DOCS.template.md packaging/home-assistant/DOCS.m
 render packaging/home-assistant/CHANGELOG.template.md packaging/home-assistant/CHANGELOG.md
 cp static/icon-512.png packaging/home-assistant/icon.png
 cp static/icon-512.png packaging/home-assistant/logo.png
-render packaging/casaos/docker-compose.template.yml packaging/casaos/docker-compose.yml
 
-python3 - "$version" "$digest" <<'PYTHON'
-from pathlib import Path
-import re
-import sys
-
-version, digest = sys.argv[1:]
-manifest = Path('packaging/umbrel/umbrel-app.yml')
-compose = Path('packaging/umbrel/docker-compose.yml')
-manifest.write_text(re.sub(r'(?m)^version: "[^"]+"$', f'version: "{version}"', manifest.read_text()))
-compose.write_text(re.sub(
-    r'(?m)^(\s*image: ghcr\.io/stadicus/popcorn-vote:)[^@\s]+@sha256:[0-9a-f]{64}$',
-    rf'\g<1>{version}@{digest}',
-    compose.read_text(),
-))
-PYTHON
-
-for package in home-assistant casaos; do
-	grep -qx "$package" packaging/required-packages.txt || printf '%s\n' "$package" >> packaging/required-packages.txt
-done
-
-bash packaging/check.sh
+grep -qx home-assistant packaging/required-packages.txt || printf '%s\n' home-assistant >> packaging/required-packages.txt
+RELEASE_DATE=$(date -u +%F) bash packaging/prepare-store-update.sh "$version" "$digest"
 echo "Release metadata for $version is materialized and locally validated."
 echo "Review and test it; this script does not commit, push, submit, or publish anything."

--- a/packaging/prepare-store-update.sh
+++ b/packaging/prepare-store-update.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Prepare store metadata that can follow a release immediately. Home Assistant
+# stays separate because it requires a real HA OS device acceptance test.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: RELEASE_DATE=YYYY-MM-DD $0 <version> <manifest-list-digest>" >&2
+	exit 2
+fi
+
+version=$1
+digest=$2
+release_date=${RELEASE_DATE:-$(date -u +%F)}
+image=ghcr.io/stadicus/popcorn-vote
+
+[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid version: $version" >&2; exit 2; }
+[[ $digest =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "invalid digest: $digest" >&2; exit 2; }
+[[ $release_date =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "invalid release date: $release_date" >&2; exit 2; }
+
+cd "$(dirname "$0")/.."
+test "$(node -p "require('./package.json').version")" = "$version" || {
+	echo "package.json does not contain version $version" >&2
+	exit 1
+}
+
+inspection=$(docker buildx imagetools inspect "$image:$version")
+tag_digest=$(awk '/^Digest:[[:space:]]+sha256:/{print $2; exit}' <<<"$inspection")
+if [ "$tag_digest" != "$digest" ]; then
+	echo "$image:$version resolves to ${tag_digest:-no manifest-list digest}, not $digest" >&2
+	exit 1
+fi
+for platform in linux/amd64 linux/arm64; do
+	grep -q "Platform:[[:space:]]*$platform" <<<"$inspection" || {
+		echo "$image:$version is missing $platform" >&2
+		exit 1
+	}
+done
+
+python3 - "$version" "$digest" "$release_date" <<'PYTHON'
+from pathlib import Path
+import re
+import sys
+
+version, digest, release_date = sys.argv[1:]
+
+manifest = Path('packaging/umbrel/umbrel-app.yml')
+manifest_text, version_count = re.subn(
+    r'(?m)^version: "[^"]+"$', f'version: "{version}"', manifest.read_text(), count=1
+)
+if version_count != 1:
+    raise SystemExit('Umbrel manifest version field did not match exactly once')
+release_notes = (
+    f'Updates Popcorn Vote to version {version}. '
+    f'See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v{version}.'
+)
+manifest_text, notes_count = re.subn(
+    r'(?m)^releaseNotes:.*$', f'releaseNotes: "{release_notes}"', manifest_text, count=1
+)
+if notes_count != 1:
+    raise SystemExit('Umbrel releaseNotes field did not match exactly once')
+manifest.write_text(manifest_text)
+
+compose = Path('packaging/umbrel/docker-compose.yml')
+compose_text, image_count = re.subn(
+    r'(?m)^(\s*image: ghcr\.io/stadicus/popcorn-vote:)[^@\s]+@sha256:[0-9a-f]{64}$',
+    rf'\g<1>{version}@{digest}',
+    compose.read_text(),
+    count=1,
+)
+if image_count != 1:
+    raise SystemExit('Umbrel image field did not match exactly once')
+compose.write_text(compose_text)
+
+casa = (Path('packaging/casaos/docker-compose.template.yml').read_text()
+    .replace('__VERSION__', version)
+    .replace('__DIGEST__', digest)
+    .replace('__RELEASE_DATE__', release_date))
+if re.search(r'__[A-Z_]+__', casa):
+    raise SystemExit('CasaOS template contains an unresolved placeholder')
+Path('packaging/casaos/docker-compose.yml').write_text(casa)
+
+required = Path('packaging/required-packages.txt')
+if 'casaos' not in required.read_text().splitlines():
+    required.write_text(required.read_text().rstrip() + '\ncasaos\n')
+PYTHON
+
+bash packaging/check.sh
+echo "Umbrel and CasaOS metadata prepared for $version at $digest."

--- a/packaging/required-packages.txt
+++ b/packaging/required-packages.txt
@@ -3,3 +3,4 @@
 # first publishes it.
 unraid
 umbrel
+casaos

--- a/packaging/umbrel/umbrel-app.yml
+++ b/packaging/umbrel/umbrel-app.yml
@@ -42,7 +42,7 @@ description: >-
   server. The four-digit PIN it asks for is a house key, not a safe: whoever
   knows it can also spend other people's votes. Inside one family that is the
   point.
-releaseNotes: ""
+releaseNotes: "Updates Popcorn Vote to version 1.3.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0."
 developer: Stadicus
 website: https://popcornvote.org
 dependencies: []


### PR DESCRIPTION
## What changed

- add `packaging/prepare-store-update.sh`: one fail-closed helper that materializes Umbrel and CasaOS metadata for a given version and manifest digest, verifying against the live registry that the tag resolves to that digest and carries both amd64 and arm64
- add a `store-metadata` release job that runs the helper after a release publishes and opens a protected draft PR with the result
- materialize the digest-pinned CasaOS direct-import package and register `casaos` in `required-packages.txt`
- teach `check.sh` to require a digest pin on the CasaOS package, not just a version pin
- reduce `prepare-release-metadata.sh` to a caller of the shared helper, so manual and automated runs cannot drift

## Rebased onto current main

This PR was opened when v1.3.0 was released and had gone stale. The Umbrel v1.3.0 pin it carried has since landed on main through #28 and #31, so that part is dropped — the branch no longer touches `packaging/umbrel/docker-compose.yml`. The `docker/setup-buildx-action` pin in the new job was moved to the SHA from #30.

What remains is the automation plus the CasaOS package, neither of which is on main.

## Prerequisite before merging

The repository has no `RELEASE_PR_TOKEN` secret. This PR adds a fail-closed gate that aborts a new-version release when the token is absent, so the secret has to exist as a fine-grained token with Contents and Pull requests read/write **before** the next release runs.

## Sequencing

Merging this before the 1.4 release is what makes 1.4 open its own store-metadata PR with the real 1.4.0 digest. Merged after 1.4, the automation would first apply to 1.5 and 1.4 would need a manual run of the helper.

## Validation

- `packaging/check.sh` — packages consistent
- `shellcheck` and `bash -n` on the changed scripts
- `actionlint` on `release.yml`
- `prettier --check`
- `packaging/test-yaml-discovery.sh`

Registry lookups report SKIP locally with no registry credentials; CI resolves them live.
