### PR TITLE
fix(seo): disallow indexing of the self-hosted app

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Allow: /
+Disallow: /


### PR DESCRIPTION
## Summary
- Every self-hosted instance (including the public demo at demo.popcornvote.org) shipped `Allow: /` in `static/robots.txt`, so Google was crawling and duplicate-flagging functional app routes like `/pin`.
- Only the marketing site at popcornvote.org is meant to be indexed; the app itself is a per-instance tool, not indexable content.

## Test plan
- [x] `static/robots.txt` now returns `Disallow: /`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161d9fPQcCGPd9gGuVM5yTL