### PR TITLE
fix(umbrel): adopt root-owned app data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 - Made the production image adopt a root-owned `/data` mount once and then
   replace itself with the unprivileged `node` process. This enables managed
-  app-store storage without changing the existing explicit `--user` path used
-  by Unraid and Umbrel.
+  app-store storage without changing Unraid's existing explicit `--user` path.
 - Added the Home Assistant image labels to both native release architectures and
   CI checks that verify the labels, non-root application process, first-run
   setup, restart, update, port change, backup restore, and both supported data

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -145,20 +145,14 @@ complete setup, then stops offering it, survives an update and a restart, works
 on another host port, and comes back from a copied data directory. Two runs may
 overlap; names, ports and temporary files carry the PID.
 
-The ownership is the point of the test, and the two stores do not agree on it:
-Unraid creates appdata as `99:100`, Umbrel as `1000:1000`. The defaults above are
-Unraid's, so the Umbrel package deserves its own pass:
-
-```sh
-UIDGID=1000:1000 EXTRA='--user 1000:1000' bash packaging/test-install.sh
-```
-
-`test-root-owned-install.sh` covers the complementary app-store path used by
-Home Assistant and by Compose-based stores without a published host UID
-convention. The container adopts a root-owned mount once, leaves a platform-owned
-`options.json` alone, records `/data/.ownership-migrated`, and replaces itself
-with the application as uid 1000. If files are later copied into that directory
-as root, remove the marker and restart to repeat the migration.
+The ownership is the point of the test. Unraid creates appdata as `99:100`, so
+its template explicitly runs the container as that user. Umbrel creates the
+app-data directory as root, so its package starts the image entrypoint as root
+once; the entrypoint adopts the mount and then replaces itself with the
+application as uid 1000. `test-root-owned-install.sh` covers that path. It
+leaves a platform-owned `options.json` alone and records
+`/data/.ownership-migrated`; if files are later copied into that directory as
+root, remove the marker and restart to repeat the migration.
 
 CI runs both install paths natively on AMD64 and ARM64. For a local ARM64 check,
 run the scripts on an ARM64 host. QEMU is a slower fallback when no such host is

--- a/packaging/umbrel/docker-compose.yml
+++ b/packaging/umbrel/docker-compose.yml
@@ -16,11 +16,11 @@ services:
       PROXY_AUTH_ADD: "false"
 
   main:
-    image: ghcr.io/stadicus/popcorn-vote:1.2.0@sha256:03e8f36ca31419f656a1d4286d851945b0c890c97b9aa5b4b32fcd66f35295b6
-    # The image already runs as node, which is uid/gid 1000, matching the
-    # ownership Umbrel gives app data. Stated explicitly so a future base-image
-    # change cannot silently move it and leave the data directory unwritable.
-    user: "1000:1000"
+    image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
+    # Umbrel creates the app-data directory as root before starting the app.
+    # Start the image's entrypoint as root so it can adopt that mount once; it
+    # then replaces itself with the unprivileged node process (uid/gid 1000).
+    user: "0:0"
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/packaging/umbrel/umbrel-app.yml
+++ b/packaging/umbrel/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: popcorn-vote
 category: media
 name: Popcorn Vote
-version: "1.2.0"
+version: "1.3.0"
 tagline: Settle movie night fairly, with a vote instead of an argument
 description: >-
   No more arguing about who gets to pick the film. Everyone suggests films,
@@ -42,7 +42,7 @@ description: >-
   server. The four-digit PIN it asks for is a house key, not a safe: whoever
   knows it can also spend other people's votes. Inside one family that is the
   point.
-releaseNotes: ""
+releaseNotes: "Updates Popcorn Vote to version 1.3.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0."
 developer: Stadicus
 website: https://popcornvote.org
 dependencies: []


### PR DESCRIPTION
Updates the Umbrel metadata to Popcorn Vote 1.3.0 and starts the entrypoint as root so it can adopt Umbrel root-owned app data before dropping to UID 1000.

Verified in a fresh UmbrelOS 1.7.4 VM: install, proxy health check, setup, restart, and persisted data. `bash packaging/check.sh` passes.