### PR TITLE
fix(umbrel): run as 1000:1000, not root

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -146,13 +146,18 @@ on another host port, and comes back from a copied data directory. Two runs may
 overlap; names, ports and temporary files carry the PID.
 
 The ownership is the point of the test. Unraid creates appdata as `99:100`, so
-its template explicitly runs the container as that user. Umbrel creates the
-app-data directory as root, so its package starts the image entrypoint as root
-once; the entrypoint adopts the mount and then replaces itself with the
-application as uid 1000. `test-root-owned-install.sh` covers that path. It
-leaves a platform-owned `options.json` alone and records
-`/data/.ownership-migrated`; if files are later copied into that directory as
-root, remove the marker and restart to repeat the migration.
+its template explicitly runs the container as that user. Umbrel hands the
+committed `data/` directory to the app owned by `1000:1000` (umbreld clones the
+app store with `chown -R 1000:1000` and copies the package with
+`rsync --archive`), so its package runs the container as `1000:1000`, which is
+the image's own `node` user; CI exercises exactly that with
+`EXTRA='--user 1000:1000'`. Home Assistant and CasaOS create the mount as root,
+so those packages start the image entrypoint as root once; the entrypoint adopts
+the mount and then replaces itself with the application as uid 1000.
+`test-root-owned-install.sh` covers that path. It leaves a platform-owned
+`options.json` alone and records `/data/.ownership-migrated`; if files are later
+copied into that directory as root, remove the marker and restart to repeat the
+migration.
 
 CI runs both install paths natively on AMD64 and ARM64. For a local ARM64 check,
 run the scripts on an ARM64 host. QEMU is a slower fallback when no such host is

--- a/packaging/umbrel/docker-compose.yml
+++ b/packaging/umbrel/docker-compose.yml
@@ -17,10 +17,13 @@ services:
 
   main:
     image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
-    # Umbrel creates the app-data directory as root before starting the app.
-    # Start the image's entrypoint as root so it can adopt that mount once; it
-    # then replaces itself with the unprivileged node process (uid/gid 1000).
-    user: "0:0"
+    # umbreld clones the app store with `chown -R 1000:1000` and copies the
+    # package into app-data with `rsync --archive`, so the committed `data/`
+    # directory arrives owned by 1000:1000 (umbrel:umbrel). That is the image's
+    # own `node` user; stated explicitly so a future base-image change cannot
+    # silently move it and leave the data directory unwritable. Starting as root
+    # is neither needed here nor welcome in App Store review.
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/packaging/umbrel/umbrel-app.yml
+++ b/packaging/umbrel/umbrel-app.yml
@@ -42,7 +42,7 @@ description: >-
   server. The four-digit PIN it asks for is a house key, not a safe: whoever
   knows it can also spend other people's votes. Inside one family that is the
   point.
-releaseNotes: "Updates Popcorn Vote to version 1.3.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0."
+releaseNotes: ""
 developer: Stadicus
 website: https://popcornvote.org
 dependencies: []


### PR DESCRIPTION
Reverts the Umbrel package to `user: "1000:1000"` (#28 switched it to `0:0`) and restores `releaseNotes: ""` for the new-app submission.

Why: umbreld clones the app store with `chown -R 1000:1000` (`app-repository.ts`) and copies the package into app-data with `rsync --archive` (`apps.ts`), so the committed `data/` directory is owned by umbrel:umbrel, not root. Umbrel's packaging skill states the same, the submission in getumbrel/umbrel-apps#5994 was verified on umbrelOS 1.7.4 with `1000:1000`, and CI already tests the Umbrel contract with `--user 1000:1000`. A root-started container would be a red flag in App Store review.

The root-then-drop entrypoint is unchanged; Home Assistant and CasaOS still use it. `packaging/README.md` now says which store gets which path. `bash packaging/check.sh` passes.
