### PR TITLE
fix(docker): upgrade Alpine packages in the final stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,11 @@ COPY --from=build /app/build ./build
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./
 COPY docker-entrypoint.sh /usr/local/bin/popcorn-vote-entrypoint
-RUN apk add --no-cache su-exec && \
+# Upgrade the base image's Alpine packages first: the node image is rebuilt on
+# its own schedule, and a fixed OpenSSL in the Alpine repository should reach
+# the published image without waiting for it.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache su-exec && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx && \
     chmod 0755 /usr/local/bin/popcorn-vote-entrypoint && \
     mkdir -p /data && chown node:node /data


### PR DESCRIPTION
The Security image scan is red on every branch since the last main run: Trivy reports CVE-2026-14456 (OpenSSL 3.5.7 in `node:22-alpine`, fixed in 3.5.8-r0), and the node image has not been rebuilt yet.

`apk upgrade --no-cache` in the final stage picks up the Alpine fix at build time. Verified locally: the built image carries `libcrypto3-3.5.8-r0` / `libssl3-3.5.8-r0`.

Unblocks #31 (its CI is green apart from this scan).