### PR TITLE
release: v1.4.0 Movie night when somebody is out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,6 @@
 # Changelog
 
-## Unreleased
-
-- Made the television follow a partial night. Until now the big screen kept
-  counting every vote while the phone next to it counted only the people in the
-  room, so it could crown a film that then did not win. Who is missing is now
-  shared by all devices: tap somebody off on any phone and the board recounts
-  everywhere, their films step to the bottom saying "waits for Ben", and the
-  crown moves to whoever can actually win. The selection survives a reload,
-  reaches the free-pick dialog on a film page, and expires twelve hours after
-  the last change so an evening nobody confirmed cannot colour the next one.
-- Made "We watched it" open the archive, where the film is the top entry and
-  its stars are waiting. Rating was two taps away and easy to forget.
+## v1.4.0 Movie night when somebody is out
 
 - Added a movie night for the evenings when somebody is out. Before the reveal,
   and before a free pick, the phone can say who is missing: only the votes of
@@ -19,13 +8,26 @@
   is no candidate at all. It stays on the list, greyed out, marked "waits for
   Ben", and it cannot be chosen as a free pick either. Taking a vote back is the
   way to release a movie, exactly as it always was, so nothing new had to be
-  invented and nobody's favourite gets watched without them.
+  invented and nobody's favourite gets watched without them. Whoever ticks
+  nobody off sees no change anywhere: there is no new setting and no new
+  environment variable.
 - Recorded who was away on the movie itself, so the archive, the log and the TV
   say "Without Ben" for that evening and nothing at all for a full one.
-  Reverting a win clears it. Whoever ticks nobody off sees no change anywhere:
-  there is no new setting, no new environment variable, and the standings on the
-  television keep counting every vote, because the TV does not know who is in
-  the room.
+  Reverting a win clears it.
+- Made the television follow a partial night. Who is missing is shared by all
+  devices: tap somebody off on the evaluation page of any phone and the board
+  recounts everywhere, their films step to the bottom saying "waits for Ben",
+  and the crown moves to whoever can actually win. The selection survives a
+  reload, reaches the free-pick dialog on a film page, and expires twelve hours
+  after the last change so an evening nobody confirmed cannot colour the next
+  one. A revert keeps it: that is the same evening, run again.
+- Made "We watched it" open the archive, where the film is the top entry and
+  its stars are waiting. Rating was two taps away and easy to forget.
+- Made every new release open a draft pull request that moves Umbrel to the
+  published manifest digest and materializes the matching CasaOS package, so
+  the store metadata no longer waits for a manual run. The CasaOS package for
+  v1.3.0 is materialized for direct import; Home Assistant stays in its
+  templates until the Home Assistant OS device test has passed.
 
 ## v1.3.0 App-store runtime and release preparation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "popcorn-vote",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "popcorn-vote",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"better-sqlite3": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "popcorn-vote",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"private": true,
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## What changed

- `package.json` / `package-lock.json`: 1.3.0 → 1.4.0
- `CHANGELOG.md`: `## Unreleased` becomes `## v1.4.0 Movie night when somebody is out`. The two follow-ups (television follows the evening, archive after "watched") now sit behind the feature they belong to, and the sentence claiming the television keeps counting every vote is gone: since #35 the board follows the phone. The automated post-release store update from #25 is recorded too; it had no entry.

`.github/release-notes.sh 1.4.0` prints the section and exits 0.

## Consistency

DOCUMENTATION.md ("The TV view", "When somebody is out"), SPECIFICATION.md section 2 and the README feature list were re-read against the merged code: all three describe the shared evening state and the recounting board. No change needed. The marketing website gets its own section in a separate PR, so this release commit stays application-only for `release-scope.sh`.

## Verification (locally, on this commit)

- `npm run verify`: lint:secrets, lint, check green; unit tests 586/587, the one failure is the known local-only timeout in `src/lib/server/auth.test.ts:399` (identical on unmodified main, green in CI). `npm run build` and `npm run audit:prod` (0 vulnerabilities) run separately after it.
- `npm run test:e2e`: 21/21.
- `packaging/check.sh`, `test-registry-required.sh`, `test-yaml-discovery.sh`: green. The two Docker-based install tests run in CI only (see PR comment for the local Docker status).
- `.github/no-german-characters.sh`: clean.

## Release

Not started by this PR. After merge, the release is a manual `workflow_dispatch` on the tip of main; it waits for CI, Security and CodeQL on that exact SHA, builds amd64 and arm64, tags `v1.4.0`, and opens the Umbrel/CasaOS draft PR itself (`RELEASE_PR_TOKEN` is set).
