### PR TITLE
fix(release): install node_modules before the store metadata job runs check.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,6 +537,15 @@ jobs:
           # PAT used below. It would also suppress follow-up CI if permissions
           # were widened, so leave Git authentication to RELEASE_PR_TOKEN.
           persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      # prepare-store-update.sh ends with packaging/check.sh, which reads every
+      # package YAML through node_modules/yaml. Without the install the job
+      # fails after image, tag and release are already published, and the
+      # store PR has to be opened by hand (run 33735472935 for v1.4.0).
+      - run: npm ci
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Resolve the published manifest digest
         id: digest


### PR DESCRIPTION
## What changed

The `store-metadata` job of `release.yml` gets `actions/setup-node` (same pinned SHA, node 22, npm cache as in `ci.yml`) and `npm ci` right after the checkout.

## Why

`packaging/prepare-store-update.sh` ends with `packaging/check.sh`, which reads every package YAML through `node_modules/yaml`. The job never installed anything, so the first release that had it, v1.4.0 (run 33735472935), failed at exactly that point after image, tag and release were already published. The Umbrel/CasaOS update for v1.4.0 was therefore rendered locally and opened by hand (see the store-metadata PR).

## Checked

- `release.yml` parses with unique keys, `actionlint` and prettier are clean.
- `npm ci` on this tree has no `prepare`/`postinstall` hook, writes only `node_modules/` (ignored), so the later `git add` of the four store files and the `git diff --quiet` against an existing branch stay unaffected.
- The gate job already proves `ci.yml` (which runs `npm ci` on the same SHA) before this job starts.
- Local review gate: Sonnet, Codex, adversarial Fable. No Critical, no Major; one Nitpick about placing the install later in the job, left as is to match `ci.yml`'s order.

Workflow change, so this is for Roland to merge.