### PR TITLE
Update Umbrel and CasaOS to v1.4.0

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -14,11 +14,11 @@ package below has to be checked.
 |---|---|---|
 | `unraid/` | Unraid Community Applications | shipped |
 | `umbrel/` | Umbrel App Store | [submitted](https://github.com/getumbrel/umbrel-apps/pull/5994) |
-| `home-assistant/` | Home Assistant custom app repository | prepared for v1.3.0 |
-| `casaos/` | CasaOS direct import / later app-store contribution | materialized for v1.3.0; upstream submission pending |
+| `home-assistant/` | Home Assistant custom app repository | templates ready; waits for the HA OS device test |
+| `casaos/` | CasaOS direct import / later app-store contribution | materialized for v1.4.0; upstream submission pending |
 
 Home Assistant metadata remains in non-discoverable templates until its required
-Home Assistant OS device test has passed. CasaOS v1.3.0 is materialized for
+Home Assistant OS device test has passed. CasaOS v1.4.0 is materialized for
 direct import, while an official store submission still requires a real CasaOS
 install test and separate authorization. `prepare-release-metadata.sh` verifies
 the multi-architecture image and can render the full coordinated metadata set

--- a/packaging/casaos/README.md
+++ b/packaging/casaos/README.md
@@ -1,8 +1,8 @@
 # CasaOS package source
 
 `docker-compose.template.yml` is the reviewed source for the CasaOS package.
-The released v1.3.0 image now exists, so `docker-compose.yml` is materialized as
-a directly importable, version-pinned package.
+Every release materializes `docker-compose.yml` from it as a directly
+importable package pinned to that release's image digest.
 
 The result supports direct import through CasaOS **Install a customised app**
 and is also shaped for a later contribution to the official CasaOS/ZimaOS app

--- a/packaging/casaos/docker-compose.template.yml
+++ b/packaging/casaos/docker-compose.template.yml
@@ -47,8 +47,8 @@ x-casaos:
   version: '__VERSION__'
   update_at: '__RELEASE_DATE__'
   release_notes:
-    en_US: First CasaOS package for Popcorn Vote __VERSION__.
-    de_DE: Erstes CasaOS-Paket für Popcorn Vote __VERSION__.
+    en_US: Updates Popcorn Vote to version __VERSION__. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v__VERSION__.
+    de_DE: Aktualisiert Popcorn Vote auf Version __VERSION__. Die vollständigen Release Notes stehen unter https://github.com/Stadicus/popcorn-vote/releases/tag/v__VERSION__.
   website: https://popcornvote.org
   repo: https://github.com/Stadicus/popcorn-vote
   support: https://github.com/Stadicus/popcorn-vote/issues

--- a/packaging/casaos/docker-compose.yml
+++ b/packaging/casaos/docker-compose.yml
@@ -2,7 +2,7 @@ name: popcorn-vote
 
 services:
   popcorn-vote:
-    image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
+    image: ghcr.io/stadicus/popcorn-vote:1.4.0@sha256:eb9e21d87780a45900bebaff5ea887d6d585bcb91e52aff96b79be3bb7d2b7c6
     restart: unless-stopped
     ports:
       - target: 3000
@@ -44,11 +44,11 @@ x-casaos:
   architectures:
     - amd64
     - arm64
-  version: '1.3.0'
-  update_at: '2026-08-17'
+  version: '1.4.0'
+  update_at: '2026-09-03'
   release_notes:
-    en_US: First CasaOS package for Popcorn Vote 1.3.0.
-    de_DE: Erstes CasaOS-Paket für Popcorn Vote 1.3.0.
+    en_US: Updates Popcorn Vote to version 1.4.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.4.0.
+    de_DE: Aktualisiert Popcorn Vote auf Version 1.4.0. Die vollständigen Release Notes stehen unter https://github.com/Stadicus/popcorn-vote/releases/tag/v1.4.0.
   website: https://popcornvote.org
   repo: https://github.com/Stadicus/popcorn-vote
   support: https://github.com/Stadicus/popcorn-vote/issues

--- a/packaging/umbrel/docker-compose.yml
+++ b/packaging/umbrel/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   main:
-    image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
+    image: ghcr.io/stadicus/popcorn-vote:1.4.0@sha256:eb9e21d87780a45900bebaff5ea887d6d585bcb91e52aff96b79be3bb7d2b7c6
     # umbreld clones the app store with `chown -R 1000:1000` and copies the
     # package into app-data with `rsync --archive`, so the committed `data/`
     # directory arrives owned by 1000:1000 (umbrel:umbrel). That is the image's

--- a/packaging/umbrel/umbrel-app.yml
+++ b/packaging/umbrel/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: popcorn-vote
 category: media
 name: Popcorn Vote
-version: "1.3.0"
+version: "1.4.0"
 tagline: Settle movie night fairly, with a vote instead of an argument
 description: >-
   No more arguing about who gets to pick the film. Everyone suggests films,
@@ -42,7 +42,7 @@ description: >-
   server. The four-digit PIN it asks for is a house key, not a safe: whoever
   knows it can also spend other people's votes. Inside one family that is the
   point.
-releaseNotes: "Updates Popcorn Vote to version 1.3.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0."
+releaseNotes: "Updates Popcorn Vote to version 1.4.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.4.0."
 developer: Stadicus
 website: https://popcornvote.org
 dependencies: []


### PR DESCRIPTION
## What changed

- update Umbrel to v1.4.0 and pin the published multi-architecture manifest
- materialize the CasaOS v1.4.0 direct-import package
- the CasaOS template's release note no longer calls every version the first package; it points at the GitHub release like the Umbrel manifest does
- `packaging/README.md` and `packaging/casaos/README.md` stop naming v1.3.0

## Published artifact

- Source commit: <code>59f5eb9ae79b1842364383efb32fbf83ed2d2ba6</code>
- Manifest digest: <code>sha256:eb9e21d87780a45900bebaff5ea887d6d585bcb91e52aff96b79be3bb7d2b7c6</code>
- Verified against GHCR independently of the run: `1.4.0` and `latest` resolve to this index digest, the index carries linux/amd64 and linux/arm64, and `release-metadata-1.4.0` from run 33735472935 says the same.

Home Assistant remains gated on a real Home Assistant OS device acceptance test.

## Why by hand

The release workflow's own `store-metadata` job failed in run 33735472935 before rendering: `packaging/check.sh` needs `node_modules/yaml` and the job never ran `npm ci`. PR #38 fixes that for the next release. This branch carries the name the workflow would have used, and the four files the workflow lists are byte-identical to what `prepare-store-update.sh` renders from the new template, so a later automated run would not refuse it.

## Umbrel upstream

Not touched here. The first submission getumbrel/umbrel-apps#5994 is still open; on Roland's authorization the v1.4.0 update was pushed to the fork branch `add-popcorn-vote` as `13d7a03` (version and image digest, `releaseNotes` stays empty for a first submission), so the open submission now carries the same digest as this PR.

Local review gate: two rounds, Sonnet / Codex / adversarial Fable. Round one: one Major (the CasaOS "first package" note, fixed), one Minor (README versions, fixed), one Major about the Umbrel wording that only applies to the upstream copy and is handled there. Round two: no findings.
